### PR TITLE
feat: require explicit site for non-interactive multi-profile runs

### DIFF
--- a/src/frappe_cli/commands/auth.py
+++ b/src/frappe_cli/commands/auth.py
@@ -131,7 +131,7 @@ def whoami(ctx: typer.Context):
     """Show the resolved site and logged-in user for the active profile."""
     c = get_ctx(ctx)
     try:
-        creds = config.resolve(c.profile)
+        creds = config.resolve(c.profile, interactive=c.is_tty)
     except config.ConfigError as e:
         raise fail(str(e), 2)
     try:

--- a/src/frappe_cli/commands/guide.py
+++ b/src/frappe_cli/commands/guide.py
@@ -32,6 +32,11 @@ AUTHENTICATION
   Check who/where you are:  frappe-cli auth whoami
 
   IF YOU ARE AN AGENT / SCRIPT, credentials are not your job:
+    - Name the site explicitly on every command: pass -s <profile>, or rely on
+      FRAPPE_SITE/FRAPPE_API_KEY/FRAPPE_API_SECRET. When output is piped /
+      non-interactive the configured default profile is only auto-selected if
+      exactly one site is authenticated; with several, a bare command (no -s,
+      no env) will fail rather than guess.
     - Do NOT set, export or otherwise mutate FRAPPE_SITE / FRAPPE_API_KEY /
       FRAPPE_API_SECRET (or any FRAPPE_* variable). Read whatever the human
       already put in the environment; never write to it.

--- a/src/frappe_cli/config.py
+++ b/src/frappe_cli/config.py
@@ -166,8 +166,15 @@ def _normalize_site(site: str) -> str:
     return site
 
 
-def resolve(profile: str | None = None) -> Credentials:
-    """Resolve credentials per the documented precedence."""
+def resolve(profile: str | None = None, interactive: bool = True) -> Credentials:
+    """Resolve credentials per the documented precedence.
+
+    The configured default profile is a convenience for humans at a terminal.
+    When ``interactive`` is false (piped / agent / script invocation) the
+    default is only honoured when it is unambiguous — i.e. exactly one profile
+    is authenticated. With more than one profile the caller must pick a site
+    explicitly with ``-s/--site`` or the ``FRAPPE_*`` environment variables.
+    """
 
     env_site = os.environ.get("FRAPPE_SITE")
     # Env wins, but only when a profile wasn't explicitly requested.
@@ -181,6 +188,19 @@ def resolve(profile: str | None = None) -> Credentials:
         return Credentials(_normalize_site(env_site), key, secret, source="env")
 
     profiles, default = list_profiles()
+    # Non-interactive runs must be unambiguous. A single authenticated profile
+    # has no ambiguity, so it is used; with several, agents/scripts must name
+    # the site they operate on rather than lean on the configured default.
+    if profile is None and not interactive and len(profiles) > 1:
+        raise ConfigError(
+            "Multiple profiles are configured. Non-interactive invocations must "
+            "pick a site explicitly: pass -s/--site <profile>, or set FRAPPE_SITE, "
+            "FRAPPE_API_KEY and FRAPPE_API_SECRET. The configured default "
+            "profile is only auto-selected interactively or when it is the only one."
+        )
+    # With exactly one profile, fall back to it even when no default is set.
+    if profile is None and not interactive and len(profiles) == 1:
+        default = next(iter(profiles))
     name = profile or default
     if not name:
         raise ConfigError(

--- a/src/frappe_cli/session.py
+++ b/src/frappe_cli/session.py
@@ -10,7 +10,7 @@ from .output import Ctx, fail
 
 def get_client(ctx: Ctx) -> FrappeClient:
     try:
-        creds = config.resolve(ctx.profile)
+        creds = config.resolve(ctx.profile, interactive=ctx.is_tty)
     except config.ConfigError as e:
         raise fail(str(e), 2)
     return FrappeClient(creds.site, creds.token)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,36 @@ def test_no_config_no_env(fake_config):
         fake_config.resolve()
 
 
+def test_non_interactive_single_profile_ok(fake_config):
+    # A lone authenticated profile is unambiguous, so it is used everywhere.
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    assert fake_config.resolve(interactive=True).source == "acme"
+    assert fake_config.resolve(interactive=False).source == "acme"
+
+
+def test_non_interactive_multiple_profiles_require_explicit(fake_config):
+    # With more than one profile, the default is honoured interactively but
+    # agents/scripts must name the site.
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    fake_config.add_profile("beta", "http://beta.test", "k", "s")
+    fake_config.set_default("acme")
+    assert fake_config.resolve(interactive=True).source == "acme"
+    with pytest.raises(ConfigError):
+        fake_config.resolve(interactive=False)
+
+
+def test_non_interactive_explicit_profile_ok(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    assert fake_config.resolve("acme", interactive=False).source == "acme"
+
+
+def test_non_interactive_env_ok(fake_config, monkeypatch):
+    monkeypatch.setenv("FRAPPE_SITE", "erp.example.com")
+    monkeypatch.setenv("FRAPPE_API_KEY", "k")
+    monkeypatch.setenv("FRAPPE_API_SECRET", "s")
+    assert fake_config.resolve(interactive=False).source == "env"
+
+
 def test_remove_and_default_shift(fake_config):
     fake_config.add_profile("a", "http://a.test", "k", "s")
     fake_config.add_profile("b", "http://b.test", "k", "s")


### PR DESCRIPTION
## What

Make site selection explicit for agents/scripts. When the CLI runs non-interactively (output piped) and **more than one profile is authenticated**, it no longer silently falls back to the configured default — it refuses and asks for an explicit `-s/--site` or `FRAPPE_*` env vars.

A **single** authenticated profile is unambiguous, so it is still used automatically. Interactive (TTY) runs are unchanged and keep honouring the configured default.

## Why

The configured default profile is a human convenience. An agent that doesn't name a site could operate against the wrong one just because it happened to be the default. Forcing an explicit choice (unless there's only one option) removes that footgun.

## Behavior

`config.resolve()` gained an `interactive` flag (wired to `stdout.isatty()` via `Ctx.is_tty`). Non-interactive + no `-s` + no env:

- 0 profiles → existing "no site configured" error
- exactly 1 profile → use it
- >1 profiles → refuse, require explicit selection

`env FRAPPE_*` and explicit `-s/--site` continue to work everywhere.

## Changes

- `config.py` — `resolve(profile, interactive=True)` with the ambiguity rule
- `session.py` / `auth.py whoami` — pass `interactive=ctx.is_tty`
- `guide.py` — document the rule for agents
- `tests/test_config.py` — cover single- vs multiple-profile non-interactive cases

Full suite: 76 passed, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)