### PR TITLE
feat(auth): don't make newly authenticated sites the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ export FRAPPE_API_SECRET=yyyyyyyy
 is no plaintext secret fallback — if the keyring is unavailable, use env vars.
 
 ```sh
-frappe-cli auth login https://erp.example.com          # prompts, verifies, stores
+frappe-cli auth login https://erp.example.com
 frappe-cli auth login https://raven.example.com --name raven
-frappe-cli auth list                                   # default is marked
+frappe-cli auth login https://raven.example.com --name raven --default
+frappe-cli auth list
 frappe-cli auth default raven                          # change the default
 frappe-cli -s raven doc list "Raven Channel"           # pick a profile per command
 frappe-cli auth whoami

--- a/src/frappe_cli/commands/auth.py
+++ b/src/frappe_cli/commands/auth.py
@@ -28,7 +28,9 @@ def login(
         None, "--name", help="Profile name (default: the site host)."
     ),
     set_default: bool = typer.Option(
-        True, "--default/--no-default", help="Make this the default."
+        False,
+        "--default/--no-default",
+        help="Make this the default profile (the first profile is always the default).",
     ),
 ):
     """Store credentials for a site in the OS keyring.
@@ -70,9 +72,14 @@ def login(
     except config.ConfigError as e:
         raise fail(str(e), 2)
 
+    # The profile may still be the default even without --default: the very
+    # first profile always becomes the default (see config.add_profile).
+    _, default = config.list_profiles()
+    is_default = default == profile
+
     err_console.print(
         f"[green]logged in[/green] as {who} — profile '{profile}'"
-        + (" (default)" if set_default else "")
+        + (" (default)" if is_default else "")
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,6 +82,22 @@ def test_non_interactive_env_ok(fake_config, monkeypatch):
     assert fake_config.resolve(interactive=False).source == "env"
 
 
+def test_first_profile_always_default(fake_config):
+    # The very first profile becomes the default even without make_default,
+    # so a single-profile setup keeps working out of the box.
+    fake_config.add_profile("a", "http://a.test", "k", "s", make_default=False)
+    _, default = fake_config.list_profiles()
+    assert default == "a"
+
+
+def test_new_profile_does_not_steal_default(fake_config):
+    # Authenticating another site must not silently hijack the default.
+    fake_config.add_profile("a", "http://a.test", "k", "s")
+    fake_config.add_profile("b", "http://b.test", "k", "s", make_default=False)
+    _, default = fake_config.list_profiles()
+    assert default == "a"
+
+
 def test_remove_and_default_shift(fake_config):
     fake_config.add_profile("a", "http://a.test", "k", "s")
     fake_config.add_profile("b", "http://b.test", "k", "s")


### PR DESCRIPTION
## What

`auth login` no longer makes a newly authenticated site the default profile automatically.

## Why

The `--default/--no-default` flag defaulted to `True`, so **every** `auth login` silently promoted the new site to the default. That's surprising when you already have a working default and are just adding another site — the next bare `frappe-cli ...` command would suddenly hit the wrong site.

## Changes

- `login` now defaults to `--no-default`. Pass `--default` to opt in.
- The first-ever profile still becomes the default automatically (unchanged — handled by `add_profile`'s `default is None` clause), so single-profile setups behave exactly as before.
- The login success message now reflects the *actual* resulting default rather than the flag value.
- Added tests: first profile is always default; a second `make_default=False` profile does not steal the default.
- README updated to show the new behavior.

## Testing

`uv run --extra dev pytest` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)