### PR TITLE
ci: enable merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,29 +48,10 @@ jobs:
           SKIP: no-commit-to-branch
         run: uvx pre-commit run --all-files --show-diff-on-failure
 
-  # Required status check named `integration`. A required check must report a
-  # result on every event or PRs can't enter the queue and the queue can't
-  # merge. The expensive work lives in `integration_run` below, which only runs
-  # in the merge queue; this job just mirrors that result — failing the check
-  # when queue integration tests fail, and passing trivially everywhere else so
-  # PRs never spin up a bench or pay for integration tests.
+  # The integration suite runs only inside the merge queue, so pull requests
+  # stay fast (unit tests + linters only). Its result is rolled up by the `ci`
+  # gate job below.
   integration:
-    runs-on: ubuntu-latest
-    needs: [integration_run]
-    if: ${{ !cancelled() }}
-    steps:
-      - name: Report integration result
-        run: |
-          result="${{ needs.integration_run.result }}"
-          if [ "${{ github.event_name }}" = "merge_group" ] && [ "$result" != "success" ]; then
-            echo "Integration tests did not pass in the merge queue (result: $result)." >&2
-            exit 1
-          fi
-          echo "OK (event=${{ github.event_name }}, integration_run=$result)"
-
-  # The real integration suite. Runs only inside the merge queue, so pull
-  # requests stay fast (unit tests + linters only).
-  integration_run:
     runs-on: ubuntu-latest
     if: github.event_name == 'merge_group'
 
@@ -211,14 +192,41 @@ jobs:
         env:
           FRAPPE_SITE: http://test.localhost:8000
 
+  # Single roll-up status check — make THIS the only required check in the
+  # ruleset. It aggregates the individual jobs so the required-checks list never
+  # has to be maintained. `!cancelled()` lets it run even when integration is
+  # skipped (on PRs / pushes); it then fails unless every job that should have
+  # run for this event succeeded.
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    needs: [test, pre-commit, integration]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Verify all checks passed
+        run: |
+          echo "test=${{ needs.test.result }} pre-commit=${{ needs['pre-commit'].result }} integration=${{ needs.integration.result }} (event=${{ github.event_name }})"
+
+          # Unit tests and linters must pass on every event.
+          [ "${{ needs.test.result }}" = "success" ] || { echo "::error::unit tests failed"; exit 1; }
+          [ "${{ needs['pre-commit'].result }}" = "success" ] || { echo "::error::pre-commit failed"; exit 1; }
+
+          # Integration runs only in the merge queue; require it there, ignore
+          # its (skipped) result elsewhere.
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            [ "${{ needs.integration.result }}" = "success" ] || { echo "::error::integration tests failed"; exit 1; }
+          fi
+
+          echo "All required checks passed."
+
   release:
     name: Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # Only release after all checks pass, and only on a push to develop
+    # Only release after the CI gate passes, and only on a push to develop
     # (not PRs, which can't access the release token anyway).
-    needs: [test, pre-commit, integration]
+    needs: [ci]
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout Entire Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [develop]
   pull_request:
     branches: [develop]
+  # Fired when a PR is added to the merge queue. Required checks MUST run on
+  # this event or the queue can never merge — see the integration job below,
+  # which runs the full suite only here.
+  merge_group:
   workflow_dispatch:
 
 jobs:
@@ -44,8 +48,31 @@ jobs:
           SKIP: no-commit-to-branch
         run: uvx pre-commit run --all-files --show-diff-on-failure
 
+  # Required status check named `integration`. A required check must report a
+  # result on every event or PRs can't enter the queue and the queue can't
+  # merge. The expensive work lives in `integration_run` below, which only runs
+  # in the merge queue; this job just mirrors that result — failing the check
+  # when queue integration tests fail, and passing trivially everywhere else so
+  # PRs never spin up a bench or pay for integration tests.
   integration:
     runs-on: ubuntu-latest
+    needs: [integration_run]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Report integration result
+        run: |
+          result="${{ needs.integration_run.result }}"
+          if [ "${{ github.event_name }}" = "merge_group" ] && [ "$result" != "success" ]; then
+            echo "Integration tests did not pass in the merge queue (result: $result)." >&2
+            exit 1
+          fi
+          echo "OK (event=${{ github.event_name }}, integration_run=$result)"
+
+  # The real integration suite. Runs only inside the merge queue, so pull
+  # requests stay fast (unit tests + linters only).
+  integration_run:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
 
     services:
       mariadb:


### PR DESCRIPTION
## What

Wires up the CI workflow for the GitHub merge queue configured on the `develop` ruleset, with a single roll-up status check.

## Why

The merge queue rule is active (10-minute build window, ALLGREEN, rebase), but the workflow only triggered on `push`/`pull_request`. When the queue builds its `merge_group` branch, the checks never ran there — so the queue could never merge. The docs are explicit: required checks **must** trigger on `merge_group`.

## Changes

- **Add the `merge_group` trigger** so `test`, `pre-commit`, and `integration` run in the queue.
- **`integration` runs only in the merge queue** (`if: github.event_name == 'merge_group'`) — pull requests run unit tests + linters only, no bench provisioning.
- **Single `ci` gate job** aggregates every job's result: unit tests + linters must pass on every event; integration is additionally required in the merge queue. This is the only check that needs to be marked required.

## Net behavior

- **Pull requests** — unit tests + linters only; once they pass, the PR can be queued.
- **Merge queue** — runs the full suite (including integration) before merging into `develop`, every 10 minutes.

## Required ruleset change (manual)

Set the **`ci`** job as the **only** required status check on the `develop` ruleset, and remove the individual `test (3.10..3.14)`, `pre-commit`, and `integration` entries.

## Verify

Open a PR → only unit tests + linters run (no bench) → `ci` goes green → "Merge when ready" → the `merge_group` run executes the full integration suite before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)