### PR TITLE
ci(release): keep uv.lock in sync on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,14 @@ jobs:
         with:
           node-version: 22
 
+      # `uv` is needed by the semantic-release prepare step, which runs
+      # `uv lock` to keep the lockfile's project version in sync with the
+      # bumped pyproject.toml (both are committed in the release commit).
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: "3.14"
+
       - name: Setup dependencies
         run: |
           npm install @semantic-release/git @semantic-release/exec --no-save

--- a/.releaserc
+++ b/.releaserc
@@ -5,12 +5,12 @@
 		"@semantic-release/release-notes-generator",
 		[
 			"@semantic-release/exec", {
-				"prepareCmd": "sed -i -E 's/^version = \"[0-9]+\\.[0-9]+\\.[0-9]+\"/version = \"${nextRelease.version}\"/' pyproject.toml"
+				"prepareCmd": "sed -i -E 's/^version = \"[0-9]+\\.[0-9]+\\.[0-9]+\"/version = \"${nextRelease.version}\"/' pyproject.toml && uv lock"
 			}
 		],
 		[
 			"@semantic-release/git", {
-				"assets": ["pyproject.toml"],
+				"assets": ["pyproject.toml", "uv.lock"],
 				"message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
 			}
 		],

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "frappe-cli"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem

Automated releases only bumped and committed `pyproject.toml`. But `uv.lock` also pins the project's *own* version, so it drifted on every release — it was stuck at `0.1.1` while `pyproject.toml` had already moved to `0.2.0`.

## Fix

- **`.releaserc`**: run `uv lock` in the semantic-release `prepareCmd` (after the version `sed`), and add `uv.lock` to the `@semantic-release/git` assets so it's included in the release commit.
- **`ci.yml`**: install `uv` in the release job so the command is available.
- Re-synced the committed `uv.lock` to `0.2.0` to clear the existing drift.

`uv lock` only rewrites the project's own version line — it treats the existing lock as preferences, so transitive dependencies don't churn (verified locally: single-line diff).

### Why keep the lockfile at all?
The lockfile gives CI reproducible `uv sync` installs, so keeping it in sync is preferable to dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)