### PR TITLE
ci(release): stop release job being skipped after the ci gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,19 @@ jobs:
       contents: write
     # Only release after the CI gate passes, and only on a push to develop
     # (not PRs, which can't access the release token anyway).
+    #
+    # The `if` MUST start with a status-check function (`always()`), otherwise
+    # GitHub applies its implicit skip-propagation: because `integration` is
+    # skipped on a push, that skip taints the whole `needs` graph and this job
+    # gets skipped too — even though the intermediate `ci` job runs (it uses
+    # `!cancelled()`) and succeeds. `always()` opts out of that implicit gate,
+    # so we gate explicitly on `ci`'s result instead.
     needs: [ci]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: >-
+      always()
+      && needs.ci.result == 'success'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout Entire Repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Symptom

New pushes to `develop` (via the merge queue) stopped triggering releases. The `Release` job is **skipped**, so no version is ever cut — despite `feat`/`fix` commits landing.

## Diagnosis

On a push to `develop`, the jobs resolve like this:

| job | result | why |
|-----|--------|-----|
| `integration` | **skipped** | `if: github.event_name == 'merge_group'` |
| `ci` | **success** | has `if: ${{ !cancelled() }}`, so it runs anyway |
| `release` | **skipped** | ← the bug |

`release` had `needs: [ci]` with `if: github.event_name == 'push' && github.ref == 'refs/heads/develop'`. That `if` contains **no status-check function** (`always()`/`success()`/…), so GitHub applies its implicit skip-propagation: because `integration` in the `needs` graph was skipped, the default gate skips `release` too — even though the intermediate `ci` job ran (via `!cancelled()`) and succeeded. `!cancelled()` lets `ci` run, but it doesn't cleanse the skipped-ancestor taint for a downstream job that gates the default way.

This regressed in `71cc4e8` ("roll up checks into a single `ci` gate"). The prior config had an `integration` **mirror** job (`if: !cancelled()`) that actually *ran* on every event, so `release`'s needs were all `success`. Confirmed against real runs: `ci`=success, `integration`=skipped, `Release`=skipped.

## Fix

Start `release`'s `if` with `always()` to opt out of the implicit gate, then gate explicitly on the `ci` result:

```yaml
if: >-
  always()
  && needs.ci.result == 'success'
  && github.event_name == 'push'
  && github.ref == 'refs/heads/develop'
```

`release` now runs exactly when `ci` succeeded on a push to `develop`, regardless of whether `integration` was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)