### PR TITLE
feat(method): add API method discovery commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Serve the site
         run: |
           cd ~/frappe-bench
-          bench serve --port 8000 &
+          bench start &
           for i in $(seq 1 30); do
             if curl -sf http://test.localhost:8000/api/method/ping >/dev/null; then
               echo "site is up"; exit 0

--- a/src/frappe_cli/cli.py
+++ b/src/frappe_cli/cli.py
@@ -11,6 +11,7 @@ from . import __version__
 from .commands import api as api_cmd
 from .commands import auth, doc, doctype, file, report
 from .commands import guide as guide_cmd
+from .commands import method as method_cmd
 from .config import ConfigError
 from .errors import FrappeError, UsageError
 from .output import Ctx, fail
@@ -29,6 +30,7 @@ app.add_typer(doc.app, name="doc")
 app.add_typer(doctype.app, name="doctype")
 app.add_typer(file.app, name="file")
 app.add_typer(report.app, name="report")
+app.add_typer(method_cmd.app, name="method")
 # `frappe-cli api <path>` — single command, mounted directly.
 app.command(name="api", help=api_cmd.api.__doc__)(api_cmd.api)
 # `frappe-cli guide` — static usage primer; the first thing an agent should run.

--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -8,6 +8,7 @@ could sit on this class without touching the CLI.
 from __future__ import annotations
 
 import json
+import time
 from typing import Any, BinaryIO
 
 import httpx
@@ -15,6 +16,13 @@ import httpx
 from .errors import FrappeError, extract_message
 
 DEFAULT_TIMEOUT = 60.0
+
+# Discovery is cache-backed: a cold cache answers 503 while the server queues
+# generation. Retry a bounded number of times, honouring Retry-After, so a
+# command recovers from a cold cache without ever hanging.
+DISCOVERY_MAX_RETRIES = 4
+DISCOVERY_FALLBACK_BACKOFF = 2.0  # seconds, when Retry-After is absent
+DISCOVERY_MAX_RETRY_WAIT = 30.0  # never wait longer than this per attempt
 
 # Hosts for which plain HTTP is tolerated: the API secret never leaves the box.
 _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
@@ -228,6 +236,64 @@ class FrappeClient:
             return self.request("GET", path, params=params)
         # Honor the caller's verb (PUT/DELETE/…) rather than silently forcing POST.
         return self.request(verb, path, json_body=params or {})
+
+    # --- discovery ---------------------------------------------------------
+
+    def _retry_after_seconds(self, resp: httpx.Response) -> float:
+        """Seconds to wait before retrying, from Retry-After or a fallback."""
+        raw = resp.headers.get("Retry-After")
+        wait = DISCOVERY_FALLBACK_BACKOFF
+        if raw:
+            try:
+                # Retry-After is most commonly an integer number of seconds.
+                # An HTTP-date form is possible but rare here; fall back if so.
+                wait = float(raw)
+            except ValueError:
+                wait = DISCOVERY_FALLBACK_BACKOFF
+        return max(0.0, min(wait, DISCOVERY_MAX_RETRY_WAIT))
+
+    def _discovery_get(self, path: str, *, params: dict | None = None) -> Any:
+        """GET a discovery endpoint, retrying transient 503s on a cold cache.
+
+        Retries are capped so a command never hangs. A persistent 503 surfaces
+        as a FrappeError like any other failure; a 404 (unsupported site or
+        unknown method) surfaces with ``status_code == 404`` for the caller to
+        interpret.
+        """
+        attempts = 0
+        while True:
+            try:
+                resp = self._http.get(path, params=_clean_params(params))
+            except httpx.HTTPError as e:
+                raise FrappeError(f"Could not reach {self.site}: {e}") from e
+            if resp.status_code == 503 and attempts < DISCOVERY_MAX_RETRIES:
+                attempts += 1
+                time.sleep(self._retry_after_seconds(resp))
+                continue
+            return self._handle(resp)
+
+    def discovery_root(self) -> Any:
+        """Root discovery document; also a capability check for the feature."""
+        return self._discovery_get("/api/v2/discovery")
+
+    def discovery_search(self, query: str) -> Any:
+        return self._discovery_get("/api/v2/discovery/search", params={"q": query})
+
+    def discovery_list(self) -> Any:
+        return self._discovery_get("/api/v2/discovery/method")
+
+    def discovery_show(self, method: str) -> Any:
+        return self._discovery_get(f"/api/v2/discovery/method/{method}")
+
+    def discovery_supported(self) -> bool:
+        """True if this site exposes method discovery (root is not a 404)."""
+        try:
+            self.discovery_root()
+            return True
+        except FrappeError as e:
+            if e.status_code == 404:
+                return False
+            raise
 
     def upload_file(
         self,

--- a/src/frappe_cli/commands/guide.py
+++ b/src/frappe_cli/commands/guide.py
@@ -72,6 +72,12 @@ FILES
   frappe-cli file upload ./contract.pdf --doctype "Sales Invoice" --name SINV-0001 --private
   frappe-cli file download <File name|/files/url> -o out.pdf   # '-o -' streams to stdout
 
+DISCOVER METHODS (find whitelisted API methods before calling them)
+  frappe-cli method search --query="unread"          # search path/description/docstring
+  frappe-cli method list                              # all methods visible to this session
+  frappe-cli method show frappe.tests.test_api.test   # params, http methods, endpoint
+  # Results are session-scoped; requires a Frappe site that supports discovery.
+
 RAW API (the escape hatch for anything the verbs above don't cover)
   frappe-cli api method/frappe.client.get_count -F doctype=User    # -F typed, -f string
   frappe-cli api method/gameplan.api.get_unread_count

--- a/src/frappe_cli/commands/method.py
+++ b/src/frappe_cli/commands/method.py
@@ -1,0 +1,112 @@
+"""``frappe-cli method`` — discover whitelisted API methods and server scripts.
+
+Backed by Frappe's ``/api/v2/discovery`` endpoints. Results are filtered for the
+current session: guests see guest-accessible methods, authenticated sessions see
+their whitelisted methods, and API server scripts appear only with read
+permission on ``Server Script``.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from ..errors import FrappeError
+from ..output import emit_list, emit_record, err_console, fail, get_ctx, print_json
+from ..session import get_client
+
+app = typer.Typer(no_args_is_help=True, help="Discover and inspect API methods.")
+
+# Human-facing messages for the two distinct 404 shapes discovery can produce.
+_NOT_AVAILABLE = "Method discovery is not available on this site."
+_METHOD_NOT_FOUND = "Method not found or not visible to this session."
+
+
+@app.command("search")
+def search_methods(
+    ctx: typer.Context,
+    query: str = typer.Option(..., "--query", "-q", help="Search terms."),
+):
+    """Search whitelisted methods by type, path, description and docstring."""
+    c = get_ctx(ctx)
+    client = get_client(c)
+    try:
+        result = client.discovery_search(query)
+    except FrappeError as e:
+        if e.status_code == 404:
+            raise fail(_NOT_AVAILABLE)
+        raise fail(e.message)
+
+    if c.json:
+        print_json(result)
+        return
+
+    results = result.get("results", []) if isinstance(result, dict) else []
+    emit_list(
+        c,
+        results,
+        ["path", "type", "allow_guest", "description"],
+        title=f"Methods matching {query!r}",
+    )
+
+
+@app.command("list")
+def list_methods(ctx: typer.Context):
+    """List whitelisted methods visible to the current session."""
+    c = get_ctx(ctx)
+    client = get_client(c)
+    try:
+        result = client.discovery_list()
+    except FrappeError as e:
+        if e.status_code == 404:
+            raise fail(_NOT_AVAILABLE)
+        raise fail(e.message)
+
+    if c.json:
+        print_json(result)
+        return
+
+    methods = result.get("methods", []) if isinstance(result, dict) else []
+    emit_list(c, methods, ["path", "allow_guest", "description"], title="Methods")
+
+
+@app.command("show")
+def show_method(
+    ctx: typer.Context,
+    method: str = typer.Argument(..., help="Method path, e.g. 'frappe.ping'."),
+):
+    """Show the detailed contract for a single method."""
+    c = get_ctx(ctx)
+    client = get_client(c)
+    try:
+        result = client.discovery_show(method)
+    except FrappeError as e:
+        if e.status_code == 404:
+            # A 404 here is ambiguous: either the whole feature is missing, or
+            # the method is unknown/invisible. Probe the root to disambiguate.
+            if client.discovery_supported():
+                raise fail(_METHOD_NOT_FOUND)
+            raise fail(_NOT_AVAILABLE)
+        raise fail(e.message)
+
+    if c.json:
+        print_json(result)
+        return
+
+    params = result.get("params", []) if isinstance(result, dict) else []
+    emit_record(
+        c,
+        {
+            "path": result.get("path"),
+            "name": result.get("name"),
+            "allow_guest": bool(result.get("allow_guest")),
+            "http_methods": ", ".join(result.get("http_methods") or []),
+            "endpoint": result.get("endpoint"),
+            "docstring": result.get("docstring"),
+        },
+        title=f"Method {method}",
+    )
+    if params:
+        err_console.print("[bold]Parameters[/bold]")
+        emit_list(c, params, ["name", "type", "required", "default"])
+    else:
+        err_console.print("[dim]No parameters.[/dim]")

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -121,6 +121,38 @@ def test_doc_crud_lifecycle():
     assert missing.returncode == 1
 
 
+# frappe.ping is the ideal smoke method: guest-accessible, parameter-free, and
+# present on every Frappe site that exposes discovery at all.
+PING = "frappe.ping"
+
+
+def test_method_list_includes_ping():
+    result = run_json("method", "list")
+    paths = {m["path"] for m in result["methods"]}
+    assert PING in paths
+
+
+def test_method_search_finds_ping():
+    result = run_json("method", "search", "-q", "ping")
+    hit = next(r for r in result["results"] if r["path"] == PING)
+    assert hit["allow_guest"] is True
+
+
+def test_method_show_exposes_contract():
+    result = run_json("method", "show", PING)
+    assert result["path"] == PING
+    assert result["allow_guest"] is True
+    assert result["endpoint"] == f"/api/v2/method/{PING}"
+    assert "GET" in result["http_methods"]
+
+
+def test_method_show_missing_reports_clean_error():
+    proc = run("method", "show", f"frappe.does_not_exist_{uuid.uuid4().hex}")
+    assert proc.returncode == 1
+    assert proc.stdout.strip() == ""  # no half-baked JSON on stdout
+    assert proc.stderr.strip()  # a human-readable error on stderr
+
+
 def test_delete_refuses_without_confirmation():
     # Non-interactive delete without --yes must refuse (usage error, code 2)
     # before it ever touches the server.

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1,0 +1,157 @@
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from frappe_cli import client as client_mod
+from frappe_cli.cli import app
+from frappe_cli.client import FrappeClient
+from frappe_cli.errors import FrappeError
+
+BASE = "http://localhost"
+runner = CliRunner()
+
+
+def _client():
+    return FrappeClient(BASE, "k:s")
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("FRAPPE_SITE", BASE)
+    monkeypatch.setenv("FRAPPE_API_KEY", "k")
+    monkeypatch.setenv("FRAPPE_API_SECRET", "s")
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    # Never actually sleep during retry tests.
+    monkeypatch.setattr(client_mod.time, "sleep", lambda _s: None)
+
+
+# --- client ---------------------------------------------------------------
+
+
+@respx.mock
+def test_discovery_search_hits_singular_endpoint():
+    route = respx.get(f"{BASE}/api/v2/discovery/search").mock(
+        return_value=httpx.Response(
+            200, json={"data": {"query": "abc", "results": [{"path": "x"}]}}
+        )
+    )
+    out = _client().discovery_search("abc")
+    assert out == {"query": "abc", "results": [{"path": "x"}]}
+    assert route.calls.last.request.url.params["q"] == "abc"
+
+
+@respx.mock
+def test_discovery_list_uses_singular_method_route():
+    respx.get(f"{BASE}/api/v2/discovery/method").mock(
+        return_value=httpx.Response(
+            200, json={"data": {"type": "method_index", "methods": []}}
+        )
+    )
+    assert _client().discovery_list()["type"] == "method_index"
+
+
+@respx.mock
+def test_discovery_retries_503_then_succeeds():
+    route = respx.get(f"{BASE}/api/v2/discovery/method").mock(
+        side_effect=[
+            httpx.Response(503, headers={"Retry-After": "0"}),
+            httpx.Response(200, json={"data": {"methods": []}}),
+        ]
+    )
+    assert _client().discovery_list() == {"methods": []}
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_discovery_gives_up_after_max_retries():
+    respx.get(f"{BASE}/api/v2/discovery/method").mock(
+        return_value=httpx.Response(503, headers={"Retry-After": "0"})
+    )
+    with pytest.raises(FrappeError) as ei:
+        _client().discovery_list()
+    assert ei.value.status_code == 503
+
+
+@respx.mock
+def test_discovery_supported_false_on_404():
+    respx.get(f"{BASE}/api/v2/discovery").mock(return_value=httpx.Response(404))
+    assert _client().discovery_supported() is False
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+@respx.mock
+def test_method_search_json_is_raw(env):
+    respx.get(f"{BASE}/api/v2/discovery/search").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"query": "abc", "results": [{"path": "frappe.ping"}]}},
+        )
+    )
+    result = runner.invoke(app, ["--json", "method", "search", "--query=abc"])
+    assert result.exit_code == 0
+    assert '"query": "abc"' in result.stdout
+    assert "frappe.ping" in result.stdout
+
+
+@respx.mock
+def test_method_list_404_reports_unavailable(env):
+    respx.get(f"{BASE}/api/v2/discovery/method").mock(return_value=httpx.Response(404))
+    result = runner.invoke(app, ["--json", "method", "list"])
+    assert result.exit_code == 1
+    assert "not available on this site" in result.stderr
+
+
+@respx.mock
+def test_method_show_404_but_discovery_supported(env):
+    respx.get(f"{BASE}/api/v2/discovery/method/frappe.nope").mock(
+        return_value=httpx.Response(404)
+    )
+    respx.get(f"{BASE}/api/v2/discovery").mock(
+        return_value=httpx.Response(200, json={"data": {"type": "discovery"}})
+    )
+    result = runner.invoke(app, ["--json", "method", "show", "frappe.nope"])
+    assert result.exit_code == 1
+    assert "not found or not visible" in result.stderr
+
+
+@respx.mock
+def test_method_show_404_when_discovery_absent(env):
+    respx.get(f"{BASE}/api/v2/discovery/method/frappe.nope").mock(
+        return_value=httpx.Response(404)
+    )
+    respx.get(f"{BASE}/api/v2/discovery").mock(return_value=httpx.Response(404))
+    result = runner.invoke(app, ["--json", "method", "show", "frappe.nope"])
+    assert result.exit_code == 1
+    assert "not available on this site" in result.stderr
+
+
+@respx.mock
+def test_method_show_json_preserved_after_503_retry(env):
+    respx.get(f"{BASE}/api/v2/discovery/method/frappe.ping").mock(
+        side_effect=[
+            httpx.Response(503, headers={"Retry-After": "0"}),
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "type": "method",
+                        "path": "frappe.ping",
+                        "name": "ping",
+                        "http_methods": ["GET", "POST"],
+                        "params": [],
+                        "endpoint": "/api/v2/method/frappe.ping",
+                        "allow_guest": True,
+                    }
+                },
+            ),
+        ]
+    )
+    result = runner.invoke(app, ["--json", "method", "show", "frappe.ping"])
+    assert result.exit_code == 0
+    assert '"path": "frappe.ping"' in result.stdout


### PR DESCRIPTION
Adds `frappe-cli method search|list|show`, backed by Frappe's API v2 discovery endpoints for whitelisted RPC methods and API server scripts.

## Commands
- `frappe-cli method search --query="abc"` → `GET /api/v2/discovery/search?q=abc`
- `frappe-cli method list` → `GET /api/v2/discovery/method`
- `frappe-cli method show method.path` → `GET /api/v2/discovery/method/{method}`

All use the **singular** `discovery/method` route. Each supports `--json` (prints the raw discovery payload) or a human-readable table/record.

## Client layer
- `discovery_search/list/show/root` helpers on `FrappeClient`.
- Cold-cache **503** handling: bounded retries honouring `Retry-After`, with a capped fallback backoff, so a command recovers from a queued cache generation without ever hanging.
- **404** disambiguation:
  - search/list → *"Method discovery is not available on this site."*
  - `show` probes the root discovery endpoint: if discovery exists → *"Method not found or not visible to this session."*, otherwise the unavailable message.
- No fallback to guessing method metadata.

## Docs & tests
- `frappe-cli guide` gains a "DISCOVER METHODS" section.
- New `tests/test_method.py` covers singular routes, the `q` param, 503-retry-then-succeed, retry exhaustion, both 404 paths, and raw-JSON preservation after a retry.

Verified end-to-end against a live Frappe site exposing the discovery endpoints (search/list/show, JSON + TTY rendering, and the not-found disambiguation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)