### PR TITLE
feat(auth): reconfigure sites with a shorthand name and description

### DIFF
--- a/src/frappe_cli/commands/auth.py
+++ b/src/frappe_cli/commands/auth.py
@@ -25,7 +25,12 @@ def login(
     ctx: typer.Context,
     site: str = typer.Argument(..., help="Site URL, e.g. https://erp.example.com"),
     name: Optional[str] = typer.Option(
-        None, "--name", help="Profile name (default: the site host)."
+        None, "--name", help="Profile name / shorthand (default: the site host)."
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        help="Note describing the site; assistant mode uses it to pick a site.",
     ),
     set_default: bool = typer.Option(
         False,
@@ -51,12 +56,23 @@ def login(
             2,
         )
 
-    profile = name or _default_profile_name(config._normalize_site(site))
+    norm_site = config._normalize_site(site)
+
+    # A friendly shorthand and a description are both prompted for (with sane
+    # defaults) unless supplied as flags, so a stored site is easy to pick
+    # later — by a human at `auth list` or by an agent in assistant mode.
+    profile = (
+        name
+        if name is not None
+        else typer.prompt("Profile name", default=_default_profile_name(norm_site))
+    )
+    if description is None:
+        description = typer.prompt(
+            "Description (used by assistant mode; optional)", default=""
+        )
 
     api_key = typer.prompt("API key")
     api_secret = typer.prompt("API secret", hide_input=True)
-
-    norm_site = config._normalize_site(site)
 
     # Verify before storing so we never persist dead credentials.
     try:
@@ -67,7 +83,12 @@ def login(
 
     try:
         config.add_profile(
-            profile, norm_site, api_key, api_secret, make_default=set_default
+            profile,
+            norm_site,
+            api_key,
+            api_secret,
+            make_default=set_default,
+            description=description or "",
         )
     except config.ConfigError as e:
         raise fail(str(e), 2)
@@ -96,11 +117,12 @@ def list_profiles(ctx: typer.Context):
         {
             "profile": name,
             "site": info.get("site", ""),
+            "description": info.get("description", ""),
             "default": name == default,
         }
         for name, info in profiles.items()
     ]
-    emit_list(c, rows, ["profile", "site", "default"])
+    emit_list(c, rows, ["profile", "site", "description", "default"])
     if not rows and not c.json:
         err_console.print(
             "[dim]No profiles. Run 'frappe-cli auth login <url>' or use FRAPPE_SITE env vars.[/dim]"
@@ -133,6 +155,60 @@ def set_default(
     err_console.print(f"[green]default[/green] is now '{name}'")
 
 
+@app.command("configure")
+def configure(
+    ctx: typer.Context,
+    profile: str = typer.Argument(..., help="Profile to reconfigure."),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="New profile name / shorthand."
+    ),
+    description: Optional[str] = typer.Option(
+        None,
+        "--description",
+        help="New description; pass an empty string to clear it.",
+    ),
+):
+    """Reconfigure a stored site: rename it and/or change its description.
+
+    With no flags on a terminal, both fields are prompted for with their
+    current values as defaults. Credentials are never touched here — use
+    'auth login' to re-enter an API key/secret.
+    """
+    try:
+        profiles, _ = config.list_profiles()
+    except config.ConfigError as e:
+        raise fail(str(e), 2)
+    if profile not in profiles:
+        raise fail(
+            f"No such profile: {profile}. Run 'frappe-cli auth list' to see profiles.",
+            2,
+        )
+    current_desc = profiles[profile].get("description", "")
+
+    # Nothing on the command line: prompt interactively, or refuse when there
+    # is no terminal to prompt at (a flag would then be required).
+    if name is None and description is None:
+        if not sys.stdin.isatty():
+            raise fail(
+                "Nothing to change. Pass --name and/or --description "
+                "(this command only prompts on a terminal).",
+                2,
+            )
+        name = typer.prompt("Profile name", default=profile)
+        description = typer.prompt("Description", default=current_desc)
+
+    try:
+        if name is not None and name != profile:
+            config.rename_profile(profile, name)
+            profile = name
+        if description is not None:
+            config.set_description(profile, description)
+    except config.ConfigError as e:
+        raise fail(str(e), 2)
+
+    err_console.print(f"[green]updated[/green] profile '{profile}'")
+
+
 @app.command("whoami")
 def whoami(ctx: typer.Context):
     """Show the resolved site and logged-in user for the active profile."""
@@ -148,4 +224,12 @@ def whoami(ctx: typer.Context):
         raise fail(e.message)
     from ..output import emit_record
 
-    emit_record(c, {"site": creds.site, "user": user, "source": creds.source})
+    emit_record(
+        c,
+        {
+            "site": creds.site,
+            "user": user,
+            "source": creds.source,
+            "description": creds.description,
+        },
+    )

--- a/src/frappe_cli/commands/guide.py
+++ b/src/frappe_cli/commands/guide.py
@@ -26,9 +26,12 @@ AUTHENTICATION
          FRAPPE_API_SECRET=yyyy
     2. Stored profiles (interactive, human-run):
          frappe-cli auth login https://erp.example.com      # prompts, verifies, stores
-         frappe-cli auth list                                # default is marked
+         frappe-cli auth list                                # name, site, description, default
          frappe-cli auth default <profile>                   # change the default
+         frappe-cli auth configure <profile> --name <new> --description "..."  # rename / describe
          frappe-cli -s <profile> doc list ToDo               # pick a profile per command
+  A profile's description is a human-written note; in assistant mode read
+  `frappe-cli auth list` to pick the right site by its description.
   Check who/where you are:  frappe-cli auth whoami
 
   IF YOU ARE AN AGENT / SCRIPT, credentials are not your job:

--- a/src/frappe_cli/config.py
+++ b/src/frappe_cli/config.py
@@ -33,6 +33,9 @@ class Credentials:
     api_secret: str
     # Where these came from, for error messages: "env" or a profile name.
     source: str
+    # Human-provided note describing the site (assistant mode uses this to
+    # pick the right site). Empty for env-sourced credentials.
+    description: str = ""
 
     @property
     def token(self) -> str:
@@ -130,13 +133,56 @@ def list_profiles() -> tuple[dict[str, dict], str | None]:
 
 
 def add_profile(
-    name: str, site: str, api_key: str, api_secret: str, make_default: bool = True
+    name: str,
+    site: str,
+    api_key: str,
+    api_secret: str,
+    make_default: bool = True,
+    description: str = "",
 ) -> None:
     data = _load()
     _store_secret(name, f"{api_key}:{api_secret}")
-    data["profiles"][name] = {"site": site}
+    entry = {"site": site}
+    if description:
+        entry["description"] = description
+    data["profiles"][name] = entry
     if make_default or data["default"] is None:
         data["default"] = name
+    _save(data)
+
+
+def rename_profile(name: str, new_name: str) -> None:
+    """Rename a profile, moving its secret and default pointer with it."""
+    data = _load()
+    if name not in data["profiles"]:
+        raise ConfigError(f"No such profile: {name}")
+    if new_name == name:
+        return
+    if not new_name:
+        raise ConfigError("New profile name must not be empty.")
+    if new_name in data["profiles"]:
+        raise ConfigError(f"A profile named '{new_name}' already exists.")
+
+    # Move the secret first so a keyring failure can't orphan the config entry.
+    token = _read_secret(name)
+    if token:
+        _store_secret(new_name, token)
+        _delete_secret(name)
+    data["profiles"][new_name] = data["profiles"].pop(name)
+    if data["default"] == name:
+        data["default"] = new_name
+    _save(data)
+
+
+def set_description(name: str, description: str) -> None:
+    """Set (or clear, with an empty string) a profile's description."""
+    data = _load()
+    if name not in data["profiles"]:
+        raise ConfigError(f"No such profile: {name}")
+    if description:
+        data["profiles"][name]["description"] = description
+    else:
+        data["profiles"][name].pop("description", None)
     _save(data)
 
 
@@ -220,5 +266,9 @@ def resolve(profile: str | None = None, interactive: bool = True) -> Credentials
         )
     api_key, api_secret = token.split(":", 1)
     return Credentials(
-        _normalize_site(profiles[name]["site"]), api_key, api_secret, source=name
+        _normalize_site(profiles[name]["site"]),
+        api_key,
+        api_secret,
+        source=name,
+        description=profiles[name].get("description", ""),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,6 +187,49 @@ def test_login_has_no_secret_flags():
     )
 
 
+def test_configure_renames_and_describes(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    result = runner.invoke(
+        app,
+        ["auth", "configure", "acme", "--name", "prod", "--description", "billing box"],
+    )
+    assert result.exit_code == 0
+    profiles, default = fake_config.list_profiles()
+    assert "acme" not in profiles
+    assert profiles["prod"]["description"] == "billing box"
+    assert default == "prod"
+
+
+def test_configure_unknown_profile_errors(fake_config):
+    result = runner.invoke(app, ["auth", "configure", "ghost", "--name", "x"])
+    assert result.exit_code == 2
+    assert "No such profile" in result.stderr
+
+
+def test_configure_no_flags_non_interactive_errors(fake_config):
+    # No TTY in the test runner and no flags: nothing to change, must refuse.
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    result = runner.invoke(app, ["auth", "configure", "acme"])
+    assert result.exit_code == 2
+    assert "Nothing to change" in result.stderr
+
+
+def test_configure_clears_description(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s", description="old")
+    result = runner.invoke(app, ["auth", "configure", "acme", "--description", ""])
+    assert result.exit_code == 0
+    assert "description" not in fake_config.list_profiles()[0]["acme"]
+
+
+def test_list_shows_description(fake_config):
+    fake_config.add_profile(
+        "acme", "http://acme.test", "k", "s", description="prod erp"
+    )
+    result = runner.invoke(app, ["--json", "auth", "list"])
+    assert result.exit_code == 0
+    assert "prod erp" in result.stdout
+
+
 @respx.mock
 def test_error_includes_hint(env):
     respx.get(f"{BASE}/api/v2/document/ToDo/X/").mock(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,6 +107,61 @@ def test_remove_and_default_shift(fake_config):
     assert default == "b"
 
 
+def test_description_roundtrip(fake_config):
+    fake_config.add_profile(
+        "acme", "http://acme.test", "k", "s", description="prod billing"
+    )
+    profiles, _ = fake_config.list_profiles()
+    assert profiles["acme"]["description"] == "prod billing"
+    assert fake_config.resolve().description == "prod billing"
+
+
+def test_set_description_add_and_clear(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    fake_config.set_description("acme", "staging box")
+    assert fake_config.list_profiles()[0]["acme"]["description"] == "staging box"
+    # Empty string clears the key entirely rather than storing "".
+    fake_config.set_description("acme", "")
+    assert "description" not in fake_config.list_profiles()[0]["acme"]
+
+
+def test_set_description_unknown_profile(fake_config):
+    with pytest.raises(ConfigError):
+        fake_config.set_description("ghost", "x")
+
+
+def test_rename_profile_moves_secret_and_default(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s", description="d")
+    fake_config.rename_profile("acme", "prod")
+    profiles, default = fake_config.list_profiles()
+    assert "acme" not in profiles
+    assert profiles["prod"]["site"] == "http://acme.test"
+    assert profiles["prod"]["description"] == "d"
+    assert default == "prod"
+    # Secret follows the rename, and the resolved profile works under the new name.
+    assert fake_config.resolve("prod").token == "k:s"
+
+
+def test_rename_profile_only_updates_default_when_it_was_default(fake_config):
+    fake_config.add_profile("a", "http://a.test", "k", "s")
+    fake_config.add_profile("b", "http://b.test", "k", "s", make_default=False)
+    fake_config.rename_profile("b", "beta")
+    _, default = fake_config.list_profiles()
+    assert default == "a"
+
+
+def test_rename_profile_rejects_existing_name(fake_config):
+    fake_config.add_profile("a", "http://a.test", "k", "s")
+    fake_config.add_profile("b", "http://b.test", "k", "s")
+    with pytest.raises(ConfigError):
+        fake_config.rename_profile("a", "b")
+
+
+def test_rename_unknown_profile(fake_config):
+    with pytest.raises(ConfigError):
+        fake_config.rename_profile("ghost", "x")
+
+
 def test_config_has_no_secret(fake_config):
     fake_config.add_profile("a", "http://a.test", "key", "supersecret")
     text = fake_config.config_path().read_text()


### PR DESCRIPTION
## What

Let users reconfigure existing authenticated sites and give each one a description.

- New `frappe-cli auth configure <profile>` — rename a stored site (shorthand) and/or set its description, without re-entering credentials. On a terminal it prompts for both with current values as defaults; non-interactively it requires `--name`/`--description`.
- `frappe-cli auth login` now prompts for a shorthand **name** and a **description** (both also accepted as `--name` / `--description` flags).
- The description is stored per-profile and surfaced in `auth list` and `auth whoami`, so assistant mode can pick the right site by reading its note.

## Details

- `config.rename_profile()` moves the keyring secret and the default pointer along with the config entry; `config.set_description()` sets, or clears with an empty string.
- `Credentials` now carries `description`, populated from the resolved profile (empty for env-sourced creds).
- Credentials are never touched by `configure` — re-run `auth login` to change an API key/secret.
- `guide` documents the new command and tells agents to select a site by its description.

## Tests

Added coverage for the description round-trip, add/clear, rename (secret + default follow, name-collision + unknown-profile errors), and the `auth configure` / `auth list` CLI paths. Full suite and pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)