### PR TITLE
feat(cli): add --debug to trace requests and server SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ frappe-cli auth whoami
   pipe it to `jq`. Mutations refuse to run non-interactively without `--yes`.
 - Exit codes: `0` success, `1` failure, `2` usage error. Error detail goes to
   stderr as plain text (HTML stripped from server messages).
+- `--debug` traces every HTTP request (method, URL, headers with the credential
+  redacted) to stderr, and surfaces server-side SQL for endpoints that expose it
+  (e.g. `doc list`). It never touches stdout, so `--json` output stays clean.
 
 ## Commands
 

--- a/src/frappe_cli/cli.py
+++ b/src/frappe_cli/cli.py
@@ -55,6 +55,11 @@ def _root(
     yes: bool = typer.Option(
         False, "--yes", "-y", help="Assume yes for confirmation prompts."
     ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help="Print each HTTP request (and server SQL, where available) to stderr.",
+    ),
     version: bool = typer.Option(
         False,
         "--version",
@@ -64,14 +69,14 @@ def _root(
     ),
 ):
     """Global options apply to every subcommand."""
-    ctx.obj = Ctx(json_mode=json_out, assume_yes=yes, profile=site)
+    ctx.obj = Ctx(json_mode=json_out, assume_yes=yes, profile=site, debug=debug)
 
 
 # Global flags that must reach the top-level callback. We hoist them to the
 # front of argv so they work in gh-style trailing position too, e.g.
 #   frappe-cli doc list "Sales Invoice" --json
 # is rewritten to `frappe-cli --json doc list "Sales Invoice"`.
-_VALUELESS_GLOBALS = {"--json", "--yes", "-y"}
+_VALUELESS_GLOBALS = {"--json", "--yes", "-y", "--debug"}
 _VALUED_GLOBALS = {"-s", "--site"}
 
 

--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -132,12 +132,6 @@ class FrappeClient:
                 messages.append(str(entry.get("message", entry)))
             else:
                 messages.append(str(entry))
-        raw = body.get("_debug_messages")
-        if raw:
-            try:
-                messages.extend(str(m) for m in json.loads(raw))
-            except (json.JSONDecodeError, ValueError):
-                messages.append(str(raw))
         for message in messages:
             # Strip ANSI/control characters so a hostile server cannot inject
             # terminal escape sequences into the user's terminal.

--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -8,6 +8,7 @@ could sit on this class without touching the CLI.
 from __future__ import annotations
 
 import json
+import sys
 import time
 from typing import Any, BinaryIO
 
@@ -27,6 +28,9 @@ DISCOVERY_MAX_RETRY_WAIT = 30.0  # never wait longer than this per attempt
 # Hosts for which plain HTTP is tolerated: the API secret never leaves the box.
 _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
 
+# Never print more than this much of a request body in --debug (file uploads etc.)
+_DEBUG_BODY_LIMIT = 2000
+
 
 def _is_local_host(host: str) -> bool:
     host = (host or "").lower()
@@ -34,8 +38,16 @@ def _is_local_host(host: str) -> bool:
 
 
 class FrappeClient:
-    def __init__(self, site: str, token: str, timeout: float = DEFAULT_TIMEOUT):
+    def __init__(
+        self,
+        site: str,
+        token: str,
+        timeout: float = DEFAULT_TIMEOUT,
+        *,
+        debug: bool = False,
+    ):
         self.site = site.rstrip("/")
+        self.debug = debug
 
         # Refuse to put the API key/secret on the wire in cleartext. Plain HTTP
         # is only allowed for local development (localhost / *.localhost / loopback).
@@ -59,6 +71,13 @@ class FrappeClient:
             # httpx strips the Authorization header on cross-origin redirects,
             # so the credential is never handed to a host we did not configure.
             follow_redirects=True,
+            # --debug wires request/response logging straight into the transport,
+            # so every request (including retries and redirects) is traced.
+            event_hooks=(
+                {"request": [self._log_request], "response": [self._log_response]}
+                if debug
+                else {}
+            ),
         )
 
     def close(self) -> None:
@@ -69,6 +88,58 @@ class FrappeClient:
 
     def __exit__(self, *exc) -> None:
         self.close()
+
+    # --- debug tracing -----------------------------------------------------
+
+    @staticmethod
+    def _dbg(line: str) -> None:
+        print(line, file=sys.stderr)
+
+    def _log_request(self, request: httpx.Request) -> None:
+        self._dbg(f"→ {request.method} {request.url}")
+        for name, value in request.headers.items():
+            # Never leak the API key/secret, even to the local terminal.
+            if name.lower() == "authorization":
+                value = "token ***"
+            self._dbg(f"  {name}: {value}")
+        body = request.content
+        if body:
+            try:
+                text = body.decode("utf-8")
+            except UnicodeDecodeError:
+                self._dbg(f"  <{len(body)} bytes of binary body>")
+            else:
+                if len(text) > _DEBUG_BODY_LIMIT:
+                    text = text[:_DEBUG_BODY_LIMIT] + "… (truncated)"
+                self._dbg(f"  body: {text}")
+
+    def _log_response(self, response: httpx.Response) -> None:
+        self._dbg(f"← {response.status_code} {response.reason_phrase}")
+
+    def _emit_server_debug(self, body: Any) -> None:
+        """Surface server-side debug output (e.g. SQL) returned in the payload.
+
+        The v2 API adds a top-level ``debug`` list (SQL and friends) when a
+        request passes ``debug=1`` and the caller may see tracebacks (dev server
+        or a system user). ``request()`` unwraps ``data`` and drops the rest, so
+        pull the messages out here before they are lost.
+        """
+        if not self.debug or not isinstance(body, dict):
+            return
+        messages: list[str] = []
+        for entry in body.get("debug") or []:
+            if isinstance(entry, dict):
+                messages.append(str(entry.get("message", entry)))
+            else:
+                messages.append(str(entry))
+        raw = body.get("_debug_messages")
+        if raw:
+            try:
+                messages.extend(str(m) for m in json.loads(raw))
+            except (json.JSONDecodeError, ValueError):
+                messages.append(str(raw))
+        for message in messages:
+            self._dbg(f"  [server] {message}")
 
     # --- core request ------------------------------------------------------
 
@@ -123,6 +194,8 @@ class FrappeClient:
                 )
             raise FrappeError(extract_message(body, resp.status_code), resp.status_code)
 
+        self._emit_server_debug(body)
+
         if isinstance(body, dict) and "data" in body:
             return body["data"]
         return body
@@ -172,6 +245,9 @@ class FrappeClient:
             params["filters"] = json.dumps(filters)
         if order_by:
             params["order_by"] = order_by
+        if self.debug:
+            # Ask the server to echo the generated SQL (dev server / system user).
+            params["debug"] = "true"
 
         try:
             resp = self._http.get(
@@ -185,6 +261,7 @@ class FrappeClient:
             raise FrappeError(extract_message(body, resp.status_code), resp.status_code)
 
         body = resp.json()
+        self._emit_server_debug(body)
         return body.get("data", []), bool(body.get("has_next_page"))
 
     def get_document(self, doctype: str, name: str) -> dict:

--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -139,7 +139,10 @@ class FrappeClient:
             except (json.JSONDecodeError, ValueError):
                 messages.append(str(raw))
         for message in messages:
-            self._dbg(f"  [server] {message}")
+            # Strip ANSI/control characters so a hostile server cannot inject
+            # terminal escape sequences into the user's terminal.
+            safe = "".join(c for c in message if c >= " " or c in "\t\n")
+            self._dbg(f"  [server] {safe}")
 
     # --- core request ------------------------------------------------------
 

--- a/src/frappe_cli/commands/guide.py
+++ b/src/frappe_cli/commands/guide.py
@@ -91,6 +91,8 @@ RAW API (the escape hatch for anything the verbs above don't cover)
 TIPS FOR AGENTS
   - Pass --json (or just pipe) for machine-readable output everywhere.
   - Mutations refuse to run non-interactively without --yes.
+  - Debugging? --debug traces each request (and server SQL for `doc list`) to
+    stderr, leaving stdout/--json output clean.
   - Stuck on a name or field? Run `frappe-cli doctype show <DocType>` first.
   - `frappe-cli <command> --help` documents every flag.
 """

--- a/src/frappe_cli/output.py
+++ b/src/frappe_cli/output.py
@@ -25,9 +25,16 @@ _out_console = Console()
 class Ctx:
     """Holds run-wide output state, stashed on the Typer context object."""
 
-    def __init__(self, json_mode: bool, assume_yes: bool, profile: str | None = None):
+    def __init__(
+        self,
+        json_mode: bool,
+        assume_yes: bool,
+        profile: str | None = None,
+        debug: bool = False,
+    ):
         self.assume_yes = assume_yes
         self.profile = profile
+        self.debug = debug
         # --json forces JSON; otherwise JSON whenever stdout is not a TTY.
         self.json = json_mode or not sys.stdout.isatty()
         self.is_tty = sys.stdout.isatty()

--- a/src/frappe_cli/session.py
+++ b/src/frappe_cli/session.py
@@ -13,7 +13,7 @@ def get_client(ctx: Ctx) -> FrappeClient:
         creds = config.resolve(ctx.profile, interactive=ctx.is_tty)
     except config.ConfigError as e:
         raise fail(str(e), 2)
-    return FrappeClient(creds.site, creds.token)
+    return FrappeClient(creds.site, creds.token, debug=ctx.debug)
 
 
 def run(fn):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -161,6 +161,41 @@ def test_cross_host_redirect_does_not_forward_credential():
     assert "authorization" not in landing.calls.last.request.headers
 
 
+@respx.mock
+def test_debug_requests_sql_and_emits_server_debug(capsys):
+    # With debug on, list requests ask the server for SQL (debug=true) and the
+    # returned debug messages are printed to stderr.
+    route = respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [{"name": "a"}],
+                "has_next_page": False,
+                "debug": [
+                    {"message": "SELECT `name` FROM `tabToDo` LIMIT 1"},
+                    {"message": "Execution time: 0.2 ms"},
+                ],
+            },
+        )
+    )
+    FrappeClient(BASE, "k:s", debug=True).list_documents("ToDo", fields=["name"])
+    assert route.calls.last.request.url.params["debug"] == "true"
+    err = capsys.readouterr().err
+    assert "→ GET" in err  # request traced
+    assert "authorization: token ***" in err  # credential redacted
+    assert "[server] SELECT `name` FROM `tabToDo` LIMIT 1" in err  # SQL surfaced
+
+
+@respx.mock
+def test_no_debug_param_or_output_by_default(capsys):
+    route = respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(200, json={"data": [], "has_next_page": False})
+    )
+    client().list_documents("ToDo", fields=["name"])
+    assert "debug" not in route.calls.last.request.url.params
+    assert capsys.readouterr().err == ""
+
+
 def test_refuses_plain_http_for_remote_host():
     with pytest.raises(FrappeError) as ei:
         FrappeClient("http://erp.example.com", "k:s")


### PR DESCRIPTION
## What

Adds a global `--debug` flag that traces HTTP traffic to **stderr**:

- **Every request** is logged with method, URL, and headers — the `Authorization` header is redacted (`token ***`) so the API key/secret never lands in a log.
- **Response** status line is logged.
- **Server SQL** is surfaced for endpoints that expose it. `doc list` now sends `debug=true`, and the client prints the `debug` messages the v2 API returns (SQL + execution time), which `request()` would otherwise drop when unwrapping `data`.

All debug output goes to stderr, so `--json` / piped stdout stays clean.

The flag is hoisted like the other globals, so it works in trailing position too (`frappe-cli doc list ToDo --debug`).

## Example

```
$ frappe-cli --debug doc list ToDo --limit 2
→ GET http://dev.localhost:8000/api/v2/document/ToDo?...&debug=true
  authorization: token ***
  ...
← 200 OK
  [server] SELECT `name`,`description`,... FROM `tabToDo` LIMIT 3 /* FRAPPE_TRACE_ID: ... */
  [server] Execution time: 0.224 ms
[ ...json on stdout... ]
```

## Testing

- New unit tests: `debug=true` param is sent on list queries, request is traced, credential redacted, server debug surfaced; and that neither the param nor any stderr output appears without `--debug`.
- Full suite passes.
- Manually validated against a live Frappe site (`dev.localhost`): request tracing, SQL for `doc list`, request-only tracing for `doc get`, and silent stderr by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)