### PR TITLE
fix(doc): default list sort to 'creation desc'

### DIFF
--- a/src/frappe_cli/commands/doc.py
+++ b/src/frappe_cli/commands/doc.py
@@ -74,8 +74,8 @@ def list_docs(
         "--fields",
         help="Comma-separated fields, or '*' for all. Default: meta-driven.",
     ),
-    order_by: Optional[str] = typer.Option(
-        None, "--order-by", help="e.g. 'creation desc'."
+    order_by: str = typer.Option(
+        "creation desc", "--order-by", help="Sort order, e.g. 'creation desc'."
     ),
     limit: int = typer.Option(20, "--limit", help="Max rows."),
     all_: bool = typer.Option(False, "--all", help="Auto-paginate all matching rows."),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,6 +77,8 @@ def test_doc_list_meta_driven_fields(env):
     assert "fields" in list_route.calls.last.request.url.params
     fields = list_route.calls.last.request.url.params["fields"]
     assert "description" in fields and "status" in fields
+    # sorts by creation desc by default
+    assert list_route.calls.last.request.url.params["order_by"] == "creation desc"
 
 
 @respx.mock


### PR DESCRIPTION
`frappe doc list` now defaults to `creation desc` when `--order-by` is omitted, so newest documents show first unless the user specifies otherwise.