### PR TITLE
feat(auth): add read-only profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ frappe-cli -s raven doc list "Raven Channel"           # pick a profile per comm
 frappe-cli auth whoami
 ```
 
+### Read-only profiles
+
+Mark a profile **read-only** so it can never mutate the site — any request that
+isn't a safe (GET) HTTP method is refused before it leaves your machine. This
+covers `doc create/update/delete/submit`, `file upload` and method calls
+(`api`, `method`), while reads (`doc list/get`, `doctype show`, `report run`)
+keep working.
+
+```sh
+frappe-cli auth login https://prod.example.com --name prod --read-only
+frappe-cli auth configure prod --read-only              # flip an existing profile
+frappe-cli auth configure prod --writable               # allow writes again
+```
+
+For the headless / env-var path, set `FRAPPE_READ_ONLY=1`. A read-only profile
+can still invoke a whitelisted *read* method if you force the verb with
+`frappe-cli api method/… -X GET`.
+
 ## Output & scripting
 
 - On a TTY you get rich tables, colours and confirmation prompts.

--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -164,7 +164,7 @@ class FrappeClient:
         if self.read_only and method.upper() not in _SAFE_METHODS:
             raise FrappeError(
                 f"Refusing to send a {method.upper()} request: this profile is "
-                "read-only. Only read requests (GET) are permitted. Use a "
+                "read-only. Only GET, HEAD, and OPTIONS requests are permitted. Use a "
                 "writable profile, or pass -X GET for a whitelisted read method."
             )
         try:

--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -31,6 +31,10 @@ _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
 # Never print more than this much of a request body in --debug (file uploads etc.)
 _DEBUG_BODY_LIMIT = 2000
 
+# HTTP methods that never mutate server state. A read-only profile is allowed
+# exactly these; anything else is refused before it reaches the wire.
+_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+
 
 def _is_local_host(host: str) -> bool:
     host = (host or "").lower()
@@ -45,9 +49,11 @@ class FrappeClient:
         timeout: float = DEFAULT_TIMEOUT,
         *,
         debug: bool = False,
+        read_only: bool = False,
     ):
         self.site = site.rstrip("/")
         self.debug = debug
+        self.read_only = read_only
 
         # Refuse to put the API key/secret on the wire in cleartext. Plain HTTP
         # is only allowed for local development (localhost / *.localhost / loopback).
@@ -155,6 +161,12 @@ class FrappeClient:
         Raises :class:`FrappeError` on any non-2xx response, or
         :class:`FrappeError` wrapping a transport error.
         """
+        if self.read_only and method.upper() not in _SAFE_METHODS:
+            raise FrappeError(
+                f"Refusing to send a {method.upper()} request: this profile is "
+                "read-only. Only read requests (GET) are permitted. Use a "
+                "writable profile, or pass -X GET for a whitelisted read method."
+            )
         try:
             resp = self._http.request(
                 method,

--- a/src/frappe_cli/commands/auth.py
+++ b/src/frappe_cli/commands/auth.py
@@ -37,9 +37,9 @@ def login(
         "--default/--no-default",
         help="Make this the default profile (the first profile is always the default).",
     ),
-    read_only: bool = typer.Option(
-        False,
-        "--read-only",
+    read_only: Optional[bool] = typer.Option(
+        None,
+        "--read-only/--writable",
         help="Refuse any write (create/update/delete/method call) through this profile.",
     ),
 ):
@@ -75,6 +75,12 @@ def login(
         description = typer.prompt(
             "Description (used by assistant mode; optional)", default=""
         )
+    # Read-only is prompted like the other fields when not set explicitly;
+    # default No so a plain Enter keeps the profile writable.
+    if read_only is None:
+        read_only = typer.confirm(
+            "Read-only? (refuse all writes through this profile)", default=False
+        )
 
     api_key = typer.prompt("API key")
     api_secret = typer.prompt("API secret", hide_input=True)
@@ -94,7 +100,7 @@ def login(
             api_secret,
             make_default=set_default,
             description=description or "",
-            read_only=read_only,
+            read_only=bool(read_only),
         )
     except config.ConfigError as e:
         raise fail(str(e), 2)

--- a/src/frappe_cli/commands/auth.py
+++ b/src/frappe_cli/commands/auth.py
@@ -37,6 +37,11 @@ def login(
         "--default/--no-default",
         help="Make this the default profile (the first profile is always the default).",
     ),
+    read_only: bool = typer.Option(
+        False,
+        "--read-only",
+        help="Refuse any write (create/update/delete/method call) through this profile.",
+    ),
 ):
     """Store credentials for a site in the OS keyring.
 
@@ -89,6 +94,7 @@ def login(
             api_secret,
             make_default=set_default,
             description=description or "",
+            read_only=read_only,
         )
     except config.ConfigError as e:
         raise fail(str(e), 2)
@@ -101,6 +107,7 @@ def login(
     err_console.print(
         f"[green]logged in[/green] as {who} — profile '{profile}'"
         + (" (default)" if is_default else "")
+        + (" [read-only]" if read_only else "")
     )
 
 
@@ -118,11 +125,12 @@ def list_profiles(ctx: typer.Context):
             "profile": name,
             "site": info.get("site", ""),
             "description": info.get("description", ""),
+            "read_only": bool(info.get("read_only", False)),
             "default": name == default,
         }
         for name, info in profiles.items()
     ]
-    emit_list(c, rows, ["profile", "site", "description", "default"])
+    emit_list(c, rows, ["profile", "site", "description", "read_only", "default"])
     if not rows and not c.json:
         err_console.print(
             "[dim]No profiles. Run 'frappe-cli auth login <url>' or use FRAPPE_SITE env vars.[/dim]"
@@ -167,12 +175,19 @@ def configure(
         "--description",
         help="New description; pass an empty string to clear it.",
     ),
+    read_only: Optional[bool] = typer.Option(
+        None,
+        "--read-only/--writable",
+        help="Make this profile read-only (refuse writes) or writable again.",
+    ),
 ):
-    """Reconfigure a stored site: rename it and/or change its description.
+    """Reconfigure a stored site: rename it, change its description, or toggle
+    read-only.
 
-    With no flags on a terminal, both fields are prompted for with their
-    current values as defaults. Credentials are never touched here — use
-    'auth login' to re-enter an API key/secret.
+    With no flags on a terminal, name and description are prompted for with
+    their current values as defaults (read-only is left unchanged unless the
+    flag is passed). Credentials are never touched here — use 'auth login' to
+    re-enter an API key/secret.
     """
     try:
         profiles, _ = config.list_profiles()
@@ -187,11 +202,11 @@ def configure(
 
     # Nothing on the command line: prompt interactively, or refuse when there
     # is no terminal to prompt at (a flag would then be required).
-    if name is None and description is None:
+    if name is None and description is None and read_only is None:
         if not sys.stdin.isatty():
             raise fail(
-                "Nothing to change. Pass --name and/or --description "
-                "(this command only prompts on a terminal).",
+                "Nothing to change. Pass --name, --description and/or "
+                "--read-only/--writable (this command only prompts on a terminal).",
                 2,
             )
         name = typer.prompt("Profile name", default=profile)
@@ -203,6 +218,8 @@ def configure(
             profile = name
         if description is not None:
             config.set_description(profile, description)
+        if read_only is not None:
+            config.set_read_only(profile, read_only)
     except config.ConfigError as e:
         raise fail(str(e), 2)
 
@@ -231,5 +248,6 @@ def whoami(ctx: typer.Context):
             "user": user,
             "source": creds.source,
             "description": creds.description,
+            "read_only": creds.read_only,
         },
     )

--- a/src/frappe_cli/config.py
+++ b/src/frappe_cli/config.py
@@ -36,6 +36,9 @@ class Credentials:
     # Human-provided note describing the site (assistant mode uses this to
     # pick the right site). Empty for env-sourced credentials.
     description: str = ""
+    # When true, the client refuses any request that isn't a safe (read-only)
+    # HTTP method, so this profile can never mutate the site.
+    read_only: bool = False
 
     @property
     def token(self) -> str:
@@ -139,12 +142,15 @@ def add_profile(
     api_secret: str,
     make_default: bool = True,
     description: str = "",
+    read_only: bool = False,
 ) -> None:
     data = _load()
     _store_secret(name, f"{api_key}:{api_secret}")
-    entry = {"site": site}
+    entry: dict = {"site": site}
     if description:
         entry["description"] = description
+    if read_only:
+        entry["read_only"] = True
     data["profiles"][name] = entry
     if make_default or data["default"] is None:
         data["default"] = name
@@ -186,6 +192,18 @@ def set_description(name: str, description: str) -> None:
     _save(data)
 
 
+def set_read_only(name: str, read_only: bool) -> None:
+    """Mark a profile read-only (or clear the mark)."""
+    data = _load()
+    if name not in data["profiles"]:
+        raise ConfigError(f"No such profile: {name}")
+    if read_only:
+        data["profiles"][name]["read_only"] = True
+    else:
+        data["profiles"][name].pop("read_only", None)
+    _save(data)
+
+
 def remove_profile(name: str) -> None:
     data = _load()
     if name not in data["profiles"]:
@@ -203,6 +221,10 @@ def set_default(name: str) -> None:
         raise ConfigError(f"No such profile: {name}")
     data["default"] = name
     _save(data)
+
+
+def _env_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _normalize_site(site: str) -> str:
@@ -231,7 +253,13 @@ def resolve(profile: str | None = None, interactive: bool = True) -> Credentials
             raise ConfigError(
                 "FRAPPE_SITE is set but FRAPPE_API_KEY / FRAPPE_API_SECRET are missing."
             )
-        return Credentials(_normalize_site(env_site), key, secret, source="env")
+        return Credentials(
+            _normalize_site(env_site),
+            key,
+            secret,
+            source="env",
+            read_only=_env_truthy(os.environ.get("FRAPPE_READ_ONLY")),
+        )
 
     profiles, default = list_profiles()
     # Non-interactive runs must be unambiguous. A single authenticated profile
@@ -271,4 +299,5 @@ def resolve(profile: str | None = None, interactive: bool = True) -> Credentials
         api_secret,
         source=name,
         description=profiles[name].get("description", ""),
+        read_only=bool(profiles[name].get("read_only", False)),
     )

--- a/src/frappe_cli/session.py
+++ b/src/frappe_cli/session.py
@@ -13,7 +13,9 @@ def get_client(ctx: Ctx) -> FrappeClient:
         creds = config.resolve(ctx.profile, interactive=ctx.is_tty)
     except config.ConfigError as e:
         raise fail(str(e), 2)
-    return FrappeClient(creds.site, creds.token, debug=ctx.debug)
+    return FrappeClient(
+        creds.site, creds.token, debug=ctx.debug, read_only=creds.read_only
+    )
 
 
 def run(fn):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,12 @@ def fake_config(tmp_path, monkeypatch):
     from frappe_cli import config
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    for var in ("FRAPPE_SITE", "FRAPPE_API_KEY", "FRAPPE_API_SECRET"):
+    for var in (
+        "FRAPPE_SITE",
+        "FRAPPE_API_KEY",
+        "FRAPPE_API_SECRET",
+        "FRAPPE_READ_ONLY",
+    ):
         monkeypatch.delenv(var, raising=False)
     kr = FakeKeyring()
     monkeypatch.setattr(config, "_keyring", lambda: kr)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -206,3 +206,47 @@ def test_allows_plain_http_on_localhost():
     # Local development over http is fine — the secret never leaves the box.
     for site in ("http://localhost:8000", "http://127.0.0.1", "http://dev.localhost"):
         FrappeClient(site, "k:s").close()
+
+
+# --- read-only profile guard ----------------------------------------------
+
+
+def ro_client():
+    return FrappeClient(BASE, "k:s", read_only=True)
+
+
+@respx.mock
+def test_read_only_allows_get():
+    respx.get(f"{BASE}/api/v2/document/ToDo/X/").mock(
+        return_value=httpx.Response(200, json={"data": {"name": "X"}})
+    )
+    assert ro_client().get_document("ToDo", "X") == {"name": "X"}
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda c: c.create_document("ToDo", {"description": "hi"}),
+        lambda c: c.update_document("ToDo", "X", {"description": "hi"}),
+        lambda c: c.delete_document("ToDo", "X"),
+        lambda c: c.run_doc_method("ToDo", "X", "some_method"),
+        lambda c: c.call_method("frappe.client.set_value", params={"a": 1}),
+    ],
+)
+@respx.mock
+def test_read_only_refuses_writes(call):
+    # A catch-all route ensures the guard, not the network, is what stops us:
+    # if any request escaped it would 500 here rather than raise our message.
+    respx.route().mock(return_value=httpx.Response(500))
+    with pytest.raises(FrappeError) as ei:
+        call(ro_client())
+    assert "read-only" in ei.value.message.lower()
+
+
+@respx.mock
+def test_read_only_get_method_call_allowed():
+    route = respx.get(f"{BASE}/api/v2/method/frappe.client.get_count").mock(
+        return_value=httpx.Response(200, json={"data": 3})
+    )
+    assert ro_client().call_method("frappe.client.get_count", http_method="GET") == 3
+    assert route.called

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,3 +167,40 @@ def test_config_has_no_secret(fake_config):
     text = fake_config.config_path().read_text()
     assert "supersecret" not in text
     assert "key" not in text or "key" in '"site"'  # only the word in JSON keys
+
+
+def test_read_only_defaults_false(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    assert fake_config.resolve("acme").read_only is False
+
+
+def test_read_only_stored_and_resolved(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s", read_only=True)
+    profiles, _ = fake_config.list_profiles()
+    assert profiles["acme"]["read_only"] is True
+    assert fake_config.resolve("acme").read_only is True
+
+
+def test_set_read_only_toggles(fake_config):
+    fake_config.add_profile("acme", "http://acme.test", "k", "s")
+    fake_config.set_read_only("acme", True)
+    assert fake_config.resolve("acme").read_only is True
+    fake_config.set_read_only("acme", False)
+    assert fake_config.resolve("acme").read_only is False
+    # Cleared flag is not left dangling in the file.
+    profiles, _ = fake_config.list_profiles()
+    assert "read_only" not in profiles["acme"]
+
+
+def test_set_read_only_unknown_profile(fake_config):
+    with pytest.raises(ConfigError):
+        fake_config.set_read_only("ghost", True)
+
+
+def test_env_read_only_flag(fake_config, monkeypatch):
+    monkeypatch.setenv("FRAPPE_SITE", "erp.example.com")
+    monkeypatch.setenv("FRAPPE_API_KEY", "k")
+    monkeypatch.setenv("FRAPPE_API_SECRET", "s")
+    assert fake_config.resolve().read_only is False
+    monkeypatch.setenv("FRAPPE_READ_ONLY", "1")
+    assert fake_config.resolve().read_only is True


### PR DESCRIPTION
`--read-only` flag is now available on profiles. This isn't rock solid implementation but this ensures:
- Agents will respect it as much as possible and won't even try to write something
- Only `GET` request can be made, so unless code itself is badly written with `db.commit` or state modifying stuff, CLI won't accidentally write anything. E.g. `GET ... savedoc` will run all queries for saving doc but then run `rollback` so nothing actually happens.

<img width="1911" height="816" alt="image" src="https://github.com/user-attachments/assets/6c9a9917-f49f-4da3-9052-cd8ec2be7379" />
