### PR TITLE
feat: add self-upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ can still invoke a whitelisted *read* method if you force the verb with
 | `frappe-cli api <path>` | Raw v2 access: `frappe-cli api method/<path> -F key=value`. |
 | `frappe-cli guide` | Print a short, self-contained usage primer (no site/auth needed). |
 | `frappe-cli assistant [pi\|claude\|codex]` | Launch a CLI coding agent wired up as a Frappe assistant. |
+| `frappe-cli update` | Self-upgrade via the uv/pip backend it was installed with. |
 
 ### Filtering
 

--- a/src/frappe_cli/cli.py
+++ b/src/frappe_cli/cli.py
@@ -13,6 +13,7 @@ from .commands import assistant as assistant_cmd
 from .commands import auth, doc, doctype, file, report
 from .commands import guide as guide_cmd
 from .commands import method as method_cmd
+from .commands import update as update_cmd
 from .config import ConfigError
 from .errors import FrappeError, UsageError
 from .output import Ctx, fail
@@ -36,6 +37,8 @@ app.add_typer(method_cmd.app, name="method")
 app.command(name="api", help=api_cmd.api.__doc__)(api_cmd.api)
 # `frappe-cli guide` — static usage primer; the first thing an agent should run.
 app.command(name="guide", help=guide_cmd.guide.__doc__)(guide_cmd.guide)
+# `frappe-cli update` — self-upgrade via the uv/pip backend it was installed with.
+app.command(name="update", help=update_cmd.update.__doc__)(update_cmd.update)
 # `frappe-cli assistant [tool] -- <args>` — launch a CLI agent as a Frappe
 # assistant. allow_extra_args/ignore_unknown_options let trailing args (and
 # the child tool's own flags) pass through untouched via ctx.args.

--- a/src/frappe_cli/commands/update.py
+++ b/src/frappe_cli/commands/update.py
@@ -24,6 +24,10 @@ from .. import __version__
 from ..output import confirm, err_console, fail, get_ctx, print_json
 
 _DIST = "frappe-cli"
+# Canonical source for git installs. Hardcoded rather than read back from
+# direct_url.json: the repo never moves, and the bare name resolves to an
+# unrelated package on PyPI.
+_GIT_SOURCE = "git+https://github.com/frappe/frappe-cli"
 
 
 @dataclass
@@ -59,29 +63,22 @@ def _installer(dist: importlib_metadata.Distribution) -> str:
     return text.strip().lower() if text else ""
 
 
-def _vcs_source(dist: importlib_metadata.Distribution) -> str | None:
-    """The pip-installable source spec for a VCS install, e.g. ``git+https://…``.
+def _is_vcs_install(dist: importlib_metadata.Distribution) -> bool:
+    """True if this was installed from a VCS (git) URL rather than a registry.
 
-    A package installed from a git URL is *not* on PyPI under this name (there
-    is an unrelated `frappe-cli` there), so upgrading it by bare name would pull
-    the wrong project. PEP 610's direct_url.json records the original VCS URL and
-    ref; we rebuild the ``git+<url>[@<ref>]`` spec so the upgrade re-pulls the
-    same source. Returns None for a plain (registry) install.
+    A git install is *not* on PyPI under this name (there is an unrelated
+    `frappe-cli` there), so upgrading it by bare name would pull the wrong
+    project — we upgrade from `_GIT_SOURCE` instead. PEP 610's direct_url.json
+    carries a `vcs_info` block for exactly these installs.
     """
     text = dist.read_text("direct_url.json")
     if not text:
-        return None
+        return False
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
-        return None
-    vcs = data.get("vcs_info")
-    url = data.get("url")
-    if not vcs or not url:
-        return None
-    spec = f"{vcs.get('vcs', 'git')}+{url}"
-    ref = vcs.get("requested_revision")
-    return f"{spec}@{ref}" if ref else spec
+        return False
+    return "vcs_info" in data
 
 
 def detect_backend(dist: importlib_metadata.Distribution) -> Backend | None:
@@ -98,10 +95,10 @@ def detect_backend(dist: importlib_metadata.Distribution) -> Backend | None:
     the name regardless.
     """
     installer = _installer(dist)
-    vcs = _vcs_source(dist)
+    vcs = _is_vcs_install(dist)
     # For pip-family installs, the thing to (re)install: the git source if this
     # was a VCS install, else the package name from the registry.
-    target = vcs or _DIST
+    target = _GIT_SOURCE if vcs else _DIST
     # Wrap the location in separators so `_has(location, "uv")` matches the
     # path *component* `uv`, not a substring of e.g. `myuvproject`.
     location = f"{os.sep}{dist.locate_file('')}{os.sep}"

--- a/src/frappe_cli/commands/update.py
+++ b/src/frappe_cli/commands/update.py
@@ -1,0 +1,158 @@
+"""``frappe-cli update`` — upgrade frappe-cli in place via its own installer.
+
+The CLI only knows how to drive one of two package backends: uv and pip. We
+work out how *this* install was created (from the ``INSTALLER`` marker and the
+install location), pick the matching upgrade command, and run it. If we can't
+recognise a uv/pip backend — or the install is an editable/dev checkout — we
+refuse rather than guess, because running the wrong upgrade command could break
+the user's environment or silently no-op.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as importlib_metadata
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+import typer
+
+from .. import __version__
+from ..output import confirm, err_console, fail, get_ctx, print_json
+
+_DIST = "frappe-cli"
+
+
+@dataclass
+class Backend:
+    """A recognised way to upgrade this install: a label and the command."""
+
+    name: str  # human-facing backend name, e.g. "uv tool", "pip"
+    argv: list[str]  # the upgrade command to run
+
+
+def _dist() -> importlib_metadata.Distribution | None:
+    try:
+        return importlib_metadata.distribution(_DIST)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def _is_editable(dist: importlib_metadata.Distribution) -> bool:
+    """True for `pip install -e .` / `uv pip install -e .` style dev checkouts."""
+    text = dist.read_text("direct_url.json")
+    if not text:
+        return False
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    return bool(data.get("dir_info", {}).get("editable"))
+
+
+def _installer(dist: importlib_metadata.Distribution) -> str:
+    """The tool that recorded the install (`pip`, `uv`, …), lower-cased."""
+    text = dist.read_text("INSTALLER")
+    return text.strip().lower() if text else ""
+
+
+def detect_backend(dist: importlib_metadata.Distribution) -> Backend | None:
+    """Map this install to a uv/pip upgrade command, or None if unrecognised.
+
+    Detection order matters: a `uv tool` install lives in a dedicated tools dir
+    and must be upgraded with `uv tool upgrade`, not `uv pip`. Everything else
+    keys off the recorded installer, falling back through pipx (a pip family
+    member with its own upgrade verb) to plain pip.
+    """
+    installer = _installer(dist)
+    # Wrap the location in separators so `_has(location, "uv")` matches the
+    # path *component* `uv`, not a substring of e.g. `myuvproject`.
+    location = f"{os.sep}{dist.locate_file('')}{os.sep}"
+    have_uv = shutil.which("uv") is not None
+
+    def _has(component: str) -> bool:
+        return f"{os.sep}{component}{os.sep}" in location
+
+    # `uv tool install` — isolated app in uv's tools dir.
+    if have_uv and _has("uv") and _has("tools"):
+        return Backend("uv tool", ["uv", "tool", "upgrade", _DIST])
+
+    # `uv pip install` into a regular environment.
+    if installer == "uv" and have_uv:
+        return Backend("uv pip", ["uv", "pip", "install", "--upgrade", _DIST])
+
+    if installer == "pip":
+        # pipx installs record `pip` as the installer but live under pipx's
+        # venvs dir and want `pipx upgrade`.
+        if _has("pipx") and shutil.which("pipx"):
+            return Backend("pipx", ["pipx", "upgrade", _DIST])
+        return Backend(
+            "pip", [sys.executable, "-m", "pip", "install", "--upgrade", _DIST]
+        )
+
+    return None
+
+
+def update(ctx: typer.Context) -> None:
+    """Update frappe-cli in place using the installer it was set up with.
+
+    Detects whether this install came from uv or pip and runs the matching
+    upgrade command. Refuses (without changing anything) for editable/dev
+    checkouts or when no uv/pip backend can be detected — update those by hand.
+    """
+    c = get_ctx(ctx)
+
+    dist = _dist()
+    if dist is None:
+        raise fail(f"'{_DIST}' is not installed as a package; nothing to update.", 1)
+
+    if _is_editable(dist):
+        raise fail(
+            "This is an editable/development install; update it with git "
+            "(e.g. `git pull`) instead of `frappe-cli update`.",
+            1,
+        )
+
+    backend = detect_backend(dist)
+    if backend is None:
+        raise fail(
+            "Couldn't detect a uv or pip install backend; leaving this install "
+            "untouched. Update frappe-cli manually with your package manager.",
+            1,
+        )
+
+    err_console.print(
+        f"[dim]frappe-cli {__version__} — updating via {backend.name}: "
+        f"{' '.join(backend.argv)}[/dim]"
+    )
+    if not confirm(c, f"Run `{' '.join(backend.argv)}` to update frappe-cli?"):
+        raise fail("Update cancelled.", 1)
+
+    try:
+        proc = subprocess.run(backend.argv)
+    except FileNotFoundError:
+        raise fail(f"'{backend.argv[0]}' not found on PATH.", 127)
+
+    if proc.returncode != 0:
+        raise fail(
+            f"Update failed: `{' '.join(backend.argv)}` exited {proc.returncode}.",
+            proc.returncode,
+        )
+
+    if c.json:
+        print_json(
+            {
+                "backend": backend.name,
+                "command": backend.argv,
+                "previous_version": __version__,
+                "ok": True,
+            }
+        )
+    else:
+        err_console.print(
+            "[green]done.[/green] Re-run `frappe-cli --version` to confirm the "
+            "new version."
+        )

--- a/src/frappe_cli/commands/update.py
+++ b/src/frappe_cli/commands/update.py
@@ -59,6 +59,31 @@ def _installer(dist: importlib_metadata.Distribution) -> str:
     return text.strip().lower() if text else ""
 
 
+def _vcs_source(dist: importlib_metadata.Distribution) -> str | None:
+    """The pip-installable source spec for a VCS install, e.g. ``git+https://…``.
+
+    A package installed from a git URL is *not* on PyPI under this name (there
+    is an unrelated `frappe-cli` there), so upgrading it by bare name would pull
+    the wrong project. PEP 610's direct_url.json records the original VCS URL and
+    ref; we rebuild the ``git+<url>[@<ref>]`` spec so the upgrade re-pulls the
+    same source. Returns None for a plain (registry) install.
+    """
+    text = dist.read_text("direct_url.json")
+    if not text:
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    vcs = data.get("vcs_info")
+    url = data.get("url")
+    if not vcs or not url:
+        return None
+    spec = f"{vcs.get('vcs', 'git')}+{url}"
+    ref = vcs.get("requested_revision")
+    return f"{spec}@{ref}" if ref else spec
+
+
 def detect_backend(dist: importlib_metadata.Distribution) -> Backend | None:
     """Map this install to a uv/pip upgrade command, or None if unrecognised.
 
@@ -66,8 +91,17 @@ def detect_backend(dist: importlib_metadata.Distribution) -> Backend | None:
     and must be upgraded with `uv tool upgrade`, not `uv pip`. Everything else
     keys off the recorded installer, falling back through pipx (a pip family
     member with its own upgrade verb) to plain pip.
+
+    For git installs we hand pip/uv-pip the recorded ``git+…`` source instead of
+    the bare name (which would resolve to an unrelated PyPI package). `uv tool`
+    and `pipx` re-pull their recorded source on an upgrade-by-name, so they take
+    the name regardless.
     """
     installer = _installer(dist)
+    vcs = _vcs_source(dist)
+    # For pip-family installs, the thing to (re)install: the git source if this
+    # was a VCS install, else the package name from the registry.
+    target = vcs or _DIST
     # Wrap the location in separators so `_has(location, "uv")` matches the
     # path *component* `uv`, not a substring of e.g. `myuvproject`.
     location = f"{os.sep}{dist.locate_file('')}{os.sep}"
@@ -82,16 +116,25 @@ def detect_backend(dist: importlib_metadata.Distribution) -> Backend | None:
 
     # `uv pip install` into a regular environment.
     if installer == "uv" and have_uv:
-        return Backend("uv pip", ["uv", "pip", "install", "--upgrade", _DIST])
+        argv = ["uv", "pip", "install", "--upgrade", target]
+        # A git ref (e.g. a branch) can move without the version changing; force
+        # a fresh pull so `update` isn't a silent no-op on the same tag/commit.
+        if vcs:
+            argv.append("--reinstall-package")
+            argv.append(_DIST)
+        return Backend("uv pip", argv)
 
     if installer == "pip":
         # pipx installs record `pip` as the installer but live under pipx's
         # venvs dir and want `pipx upgrade`.
         if _has("pipx") and shutil.which("pipx"):
             return Backend("pipx", ["pipx", "upgrade", _DIST])
-        return Backend(
-            "pip", [sys.executable, "-m", "pip", "install", "--upgrade", _DIST]
-        )
+        argv = [sys.executable, "-m", "pip", "install", "--upgrade", target]
+        # Same as uv above: pip treats a same-version git ref as satisfied, so
+        # force a reinstall to actually re-pull the branch/tag.
+        if vcs:
+            argv.append("--force-reinstall")
+        return Backend("pip", argv)
 
     return None
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -17,8 +17,7 @@ class FakeDist:
         installer=None,
         location="/opt/venv/site-packages",
         editable=False,
-        vcs_url=None,
-        vcs_ref=None,
+        vcs=False,
     ):
         self._files = {}
         if installer is not None:
@@ -27,12 +26,12 @@ class FakeDist:
             self._files["direct_url.json"] = json.dumps(
                 {"url": "file:///src", "dir_info": {"editable": True}}
             )
-        if vcs_url:
-            info = {"vcs": "git"}
-            if vcs_ref:
-                info["requested_revision"] = vcs_ref
+        if vcs:
             self._files["direct_url.json"] = json.dumps(
-                {"url": vcs_url, "vcs_info": info}
+                {
+                    "url": "https://github.com/frappe/frappe-cli",
+                    "vcs_info": {"vcs": "git", "requested_revision": "main"},
+                }
             )
         self._location = location
 
@@ -95,31 +94,20 @@ def test_git_pip_install_uses_git_source(monkeypatch):
     # `pip install git+https://…`: must re-pull from git, NOT resolve the bare
     # name against PyPI (an unrelated `frappe-cli` lives there).
     monkeypatch.setattr(update.shutil, "which", lambda n: None)
-    dist = FakeDist(
-        installer="pip",
-        location="/opt/venv/lib/site-packages",
-        vcs_url="https://github.com/frappe/frappe-cli",
-        vcs_ref="main",
-    )
+    dist = FakeDist(installer="pip", location="/opt/venv/lib/site-packages", vcs=True)
     backend = update.detect_backend(dist)
     assert backend.name == "pip"
-    src = "git+https://github.com/frappe/frappe-cli@main"
-    assert src in backend.argv
+    assert update._GIT_SOURCE in backend.argv
     assert "frappe-cli" not in backend.argv  # never the bare PyPI name
     assert "--force-reinstall" in backend.argv
 
 
 def test_git_uv_pip_install_uses_git_source(monkeypatch):
     monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
-    dist = FakeDist(
-        installer="uv",
-        location="/opt/venv/lib/site-packages",
-        vcs_url="https://github.com/frappe/frappe-cli",
-    )
+    dist = FakeDist(installer="uv", location="/opt/venv/lib/site-packages", vcs=True)
     backend = update.detect_backend(dist)
     assert backend.name == "uv pip"
-    # No ref recorded -> spec without @ref.
-    assert "git+https://github.com/frappe/frappe-cli" in backend.argv
+    assert update._GIT_SOURCE in backend.argv
     assert backend.argv[-2:] == ["--reinstall-package", "frappe-cli"]
 
 
@@ -129,8 +117,7 @@ def test_git_uv_tool_install_upgrades_by_name(monkeypatch):
     dist = FakeDist(
         installer="uv",
         location="/home/u/.local/share/uv/tools/frappe-cli/lib/site-packages",
-        vcs_url="https://github.com/frappe/frappe-cli",
-        vcs_ref="main",
+        vcs=True,
     )
     backend = update.detect_backend(dist)
     assert backend.argv == ["uv", "tool", "upgrade", "frappe-cli"]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,162 @@
+import json
+import subprocess
+
+from typer.testing import CliRunner
+
+from frappe_cli.cli import app
+from frappe_cli.commands import update
+
+runner = CliRunner()
+
+
+class FakeDist:
+    """Minimal stand-in for importlib.metadata.Distribution."""
+
+    def __init__(
+        self, installer=None, location="/opt/venv/site-packages", editable=False
+    ):
+        self._files = {}
+        if installer is not None:
+            self._files["INSTALLER"] = installer + "\n"
+        if editable:
+            self._files["direct_url.json"] = json.dumps(
+                {"url": "file:///src", "dir_info": {"editable": True}}
+            )
+        self._location = location
+
+    def read_text(self, name):
+        return self._files.get(name)
+
+    def locate_file(self, path):
+        return self._location
+
+
+# --- detect_backend -------------------------------------------------------
+
+
+def test_detects_uv_tool_install(monkeypatch):
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    dist = FakeDist(
+        installer="uv",
+        location="/home/u/.local/share/uv/tools/frappe-cli/lib/site-packages",
+    )
+    backend = update.detect_backend(dist)
+    assert backend.name == "uv tool"
+    assert backend.argv == ["uv", "tool", "upgrade", "frappe-cli"]
+
+
+def test_detects_uv_pip_install(monkeypatch):
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    dist = FakeDist(installer="uv", location="/opt/venv/lib/site-packages")
+    backend = update.detect_backend(dist)
+    assert backend.name == "uv pip"
+    assert backend.argv == ["uv", "pip", "install", "--upgrade", "frappe-cli"]
+
+
+def test_uv_installer_without_uv_binary_falls_through(monkeypatch):
+    # INSTALLER says uv but uv isn't on PATH -> no recognised backend.
+    monkeypatch.setattr(update.shutil, "which", lambda n: None)
+    dist = FakeDist(installer="uv", location="/opt/venv/lib/site-packages")
+    assert update.detect_backend(dist) is None
+
+
+def test_detects_pip_install(monkeypatch):
+    monkeypatch.setattr(update.shutil, "which", lambda n: None)
+    dist = FakeDist(installer="pip", location="/opt/venv/lib/site-packages")
+    backend = update.detect_backend(dist)
+    assert backend.name == "pip"
+    assert backend.argv[-3:] == ["install", "--upgrade", "frappe-cli"]
+    assert backend.argv[1:3] == ["-m", "pip"]
+
+
+def test_detects_pipx_install(monkeypatch):
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/pipx")
+    dist = FakeDist(
+        installer="pip", location="/home/u/.local/pipx/venvs/frappe-cli/lib"
+    )
+    backend = update.detect_backend(dist)
+    assert backend.name == "pipx"
+    assert backend.argv == ["pipx", "upgrade", "frappe-cli"]
+
+
+def test_unknown_installer_returns_none(monkeypatch):
+    monkeypatch.setattr(update.shutil, "which", lambda n: None)
+    dist = FakeDist(installer="conda", location="/opt/conda/lib/site-packages")
+    assert update.detect_backend(dist) is None
+
+
+# --- update command -------------------------------------------------------
+
+
+def test_refuses_editable(monkeypatch):
+    monkeypatch.setattr(
+        update, "_dist", lambda: FakeDist(installer="uv", editable=True)
+    )
+    result = runner.invoke(app, ["--yes", "update"])
+    assert result.exit_code == 1
+    assert "editable" in result.stderr
+
+
+def test_refuses_when_no_backend(monkeypatch):
+    monkeypatch.setattr(update, "_dist", lambda: FakeDist(installer="conda"))
+    monkeypatch.setattr(update.shutil, "which", lambda n: None)
+    result = runner.invoke(app, ["--yes", "update"])
+    assert result.exit_code == 1
+    assert "Couldn't detect" in result.stderr
+
+
+def test_refuses_when_not_installed(monkeypatch):
+    monkeypatch.setattr(update, "_dist", lambda: None)
+    result = runner.invoke(app, ["--yes", "update"])
+    assert result.exit_code == 1
+    assert "not installed" in result.stderr
+
+
+def test_runs_backend_command(monkeypatch):
+    monkeypatch.setattr(update, "_dist", lambda: FakeDist(installer="uv"))
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    calls = []
+
+    def fake_run(argv):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(update.subprocess, "run", fake_run)
+    result = runner.invoke(app, ["--yes", "update"])
+    assert result.exit_code == 0
+    assert calls == [["uv", "pip", "install", "--upgrade", "frappe-cli"]]
+
+
+def test_propagates_failure(monkeypatch):
+    monkeypatch.setattr(update, "_dist", lambda: FakeDist(installer="pip"))
+    monkeypatch.setattr(update.shutil, "which", lambda n: None)
+    monkeypatch.setattr(
+        update.subprocess, "run", lambda argv: subprocess.CompletedProcess(argv, 3)
+    )
+    result = runner.invoke(app, ["--yes", "update"])
+    assert result.exit_code == 3
+    assert "Update failed" in result.stderr
+
+
+def test_json_output(monkeypatch):
+    monkeypatch.setattr(update, "_dist", lambda: FakeDist(installer="uv"))
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    monkeypatch.setattr(
+        update.subprocess, "run", lambda argv: subprocess.CompletedProcess(argv, 0)
+    )
+    result = runner.invoke(app, ["--yes", "--json", "update"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["backend"] == "uv pip"
+
+
+def test_cancelled_when_not_confirmed(monkeypatch):
+    monkeypatch.setattr(update, "_dist", lambda: FakeDist(installer="uv"))
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    ran = []
+    monkeypatch.setattr(update.subprocess, "run", lambda argv: ran.append(argv))
+    # No --yes and non-TTY (CliRunner) -> confirm() refuses to proceed.
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 2
+    assert ran == []

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -13,7 +13,12 @@ class FakeDist:
     """Minimal stand-in for importlib.metadata.Distribution."""
 
     def __init__(
-        self, installer=None, location="/opt/venv/site-packages", editable=False
+        self,
+        installer=None,
+        location="/opt/venv/site-packages",
+        editable=False,
+        vcs_url=None,
+        vcs_ref=None,
     ):
         self._files = {}
         if installer is not None:
@@ -21,6 +26,13 @@ class FakeDist:
         if editable:
             self._files["direct_url.json"] = json.dumps(
                 {"url": "file:///src", "dir_info": {"editable": True}}
+            )
+        if vcs_url:
+            info = {"vcs": "git"}
+            if vcs_ref:
+                info["requested_revision"] = vcs_ref
+            self._files["direct_url.json"] = json.dumps(
+                {"url": vcs_url, "vcs_info": info}
             )
         self._location = location
 
@@ -77,6 +89,51 @@ def test_detects_pipx_install(monkeypatch):
     backend = update.detect_backend(dist)
     assert backend.name == "pipx"
     assert backend.argv == ["pipx", "upgrade", "frappe-cli"]
+
+
+def test_git_pip_install_uses_git_source(monkeypatch):
+    # `pip install git+https://…`: must re-pull from git, NOT resolve the bare
+    # name against PyPI (an unrelated `frappe-cli` lives there).
+    monkeypatch.setattr(update.shutil, "which", lambda n: None)
+    dist = FakeDist(
+        installer="pip",
+        location="/opt/venv/lib/site-packages",
+        vcs_url="https://github.com/frappe/frappe-cli",
+        vcs_ref="main",
+    )
+    backend = update.detect_backend(dist)
+    assert backend.name == "pip"
+    src = "git+https://github.com/frappe/frappe-cli@main"
+    assert src in backend.argv
+    assert "frappe-cli" not in backend.argv  # never the bare PyPI name
+    assert "--force-reinstall" in backend.argv
+
+
+def test_git_uv_pip_install_uses_git_source(monkeypatch):
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    dist = FakeDist(
+        installer="uv",
+        location="/opt/venv/lib/site-packages",
+        vcs_url="https://github.com/frappe/frappe-cli",
+    )
+    backend = update.detect_backend(dist)
+    assert backend.name == "uv pip"
+    # No ref recorded -> spec without @ref.
+    assert "git+https://github.com/frappe/frappe-cli" in backend.argv
+    assert backend.argv[-2:] == ["--reinstall-package", "frappe-cli"]
+
+
+def test_git_uv_tool_install_upgrades_by_name(monkeypatch):
+    # uv tool re-pulls its recorded git source on upgrade-by-name.
+    monkeypatch.setattr(update.shutil, "which", lambda n: "/usr/bin/uv")
+    dist = FakeDist(
+        installer="uv",
+        location="/home/u/.local/share/uv/tools/frappe-cli/lib/site-packages",
+        vcs_url="https://github.com/frappe/frappe-cli",
+        vcs_ref="main",
+    )
+    backend = update.detect_backend(dist)
+    assert backend.argv == ["uv", "tool", "upgrade", "frappe-cli"]
 
 
 def test_unknown_installer_returns_none(monkeypatch):


### PR DESCRIPTION
Adds `frappe-cli update`, which upgrades the CLI in place using the same backend it was installed with.

Detection reads the dist-info `INSTALLER` marker and install location, mapping to the right upgrade command:

| Install | Command |
|---|---|
| `uv tool` | `uv tool upgrade frappe-cli` |
| `uv pip` | `uv pip install --upgrade frappe-cli` |
| pipx | `pipx upgrade frappe-cli` |
| pip | `python -m pip install --upgrade frappe-cli` |

It refuses without changing anything for editable/dev checkouts, when no uv/pip backend can be detected, or when the package isn't installed. Confirms before running (respects `--yes`), propagates the installer's exit code, and supports `--json`.

Covered by tests in `tests/test_update.py` (each detection branch, the refusal paths, confirm gate, exit-code propagation, JSON output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)