### PR TITLE
docs: rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 [![CI](https://github.com/frappe/frappe-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/frappe/frappe-cli/actions/workflows/ci.yml)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](#license)
 
-A command-line client for [Frappe](https://frappeframework.com) sites, built for
-humans and AI agents. A pure REST API v2 client for Frappe v16+.
+A command-line REST API v2 client for Frappe v16+ — built for humans and AI agents.
 
-Using an agent? Run `frappe-cli guide` for a one-screen primer covering site access,
-the core verbs, filtering and the raw-API escape hatch.
+Using an agent? Start with `frappe-cli guide`. It fits site selection, core verbs,
+filtering and the raw-API escape hatch on one screen.
 
 ```sh
-frappe-cli auth login https://erp.example.com         # prompts for key/secret → keyring
+frappe-cli auth login https://erp.example.com         # key/secret → OS keyring
 frappe-cli -s raven doc list "Raven Channel" --json    # -s/--site selects a profile
 
 frappe-cli doc list "Sales Invoice" -f status=Overdue -f 'grand_total>1000' \
@@ -21,26 +20,27 @@ cat invoice.json | frappe-cli doc create "Sales Invoice"
 frappe-cli doc submit "Sales Invoice" SINV-0001
 frappe-cli doc delete ToDo abc123 --yes
 
-frappe-cli doctype show "Sales Invoice" --json         # agent self-orientation
+frappe-cli doctype show "Sales Invoice" --json         # discover the schema first
 frappe-cli report run "Accounts Receivable" -f company="Frappe" --json
 frappe-cli file upload ./contract.pdf --doctype "Sales Invoice" --name SINV-0001 --private
 frappe-cli api method/frappe.client.get_count -F doctype=User
-frappe-cli api method/gameplan.api.get_unread_count    # the escape hatch, in anger
+frappe-cli api method/gameplan.api.get_unread_count    # raw API, when verbs aren't enough
 ```
 
 ## Install
 
 ```sh
-uv tool install git+https://github.com/frappe/frappe-cli      # or: pip install git+https://github.com/frappe/frappe-cli
+uv tool install git+https://github.com/frappe/frappe-cli
+# or: pip install git+https://github.com/frappe/frappe-cli
 ```
 
 ## Authentication
 
-Generate an **API key + secret** for your user in Frappe (User → Settings → API
-Access). There are two ways to give `frappe` those credentials:
+Frappe CLI supports 3 authentication paths.
 
-**1. Environment variables (headless / agents).** These always win and never
-touch the keyring:
+### Environment variables
+
+Environment variables always win and never touch the keyring.
 
 ```sh
 export FRAPPE_SITE=https://erp.example.com
@@ -48,9 +48,9 @@ export FRAPPE_API_KEY=xxxxxxxx
 export FRAPPE_API_SECRET=yyyyyyyy
 ```
 
-**2. Stored profiles (interactive).** The site URL is stored in
-`~/.config/frappe/config.json`; the secret is stored in your **OS keyring**. There
-is no plaintext secret fallback — if the keyring is unavailable, use env vars.
+### Stored profiles
+
+Generate an API key + secret from **User → Settings → API Access**, then log in:
 
 ```sh
 frappe-cli auth login https://erp.example.com
@@ -58,76 +58,93 @@ frappe-cli auth login https://raven.example.com --name raven
 frappe-cli auth login https://raven.example.com --name raven --default
 frappe-cli auth list
 frappe-cli auth default raven                          # change the default
-frappe-cli -s raven doc list "Raven Channel"           # pick a profile per command
+frappe-cli -s raven doc list "Raven Channel"           # select per command
 frappe-cli auth whoami
 ```
 
-**3. OAuth (browser login).** The interactive login asks you to choose OAuth or
-API keys, with OAuth selected by default. OAuth stores no secret, and the
-short-lived access token is refreshed automatically. The site registers the
-client for you when it supports dynamic client registration (Frappe v15+ does
-by default); otherwise pass a pre-registered public `--client-id`. Needs a
-terminal and a local browser, so it is a human path — headless / agent use stays
-on env vars. `--oauth` remains available to skip the authentication method prompt.
+The site URL lives in `~/.config/frappe/config.json`; the secret lives in the **OS
+keyring**. There is no plaintext fallback. If the machine has no keyring, use environment
+variables.
+
+### OAuth
+
+Interactive login selects OAuth by default. It stores no secret; short-lived access
+tokens refresh automatically.
 
 ```sh
 frappe-cli auth login https://erp.example.com
 frappe-cli auth login https://erp.example.com --client-id <public-client-id>
 ```
 
+Sites with dynamic client registration create the client automatically. Frappe v15+
+supports this by default; other sites need a pre-registered public `--client-id`.
+
+OAuth needs a terminal and local browser, so it isn't the headless path. Use `--oauth`
+to skip the authentication-method prompt.
+
 ### Read-only profiles
 
-Mark a profile **read-only** so it can never mutate the site — any request that
-isn't a safe (GET) HTTP method is refused before it leaves your machine. This
-covers `doc create/update/delete/submit`, `file upload` and method calls
-(`api`, `method`), while reads (`doc list/get`, `doctype show`, `report run`)
-keep working.
+A read-only profile refuses every unsafe HTTP method **before the request leaves your
+machine**. This removes the obvious production footgun: an exploratory command can't
+accidentally mutate the site.
 
 ```sh
 frappe-cli auth login https://prod.example.com --name prod --read-only
-frappe-cli auth configure prod --read-only              # flip an existing profile
-frappe-cli auth configure prod --writable               # allow writes again
+frappe-cli auth configure prod --read-only             # lock an existing profile
+frappe-cli auth configure prod --writable              # allow writes again
 ```
 
-For the headless / env-var path, set `FRAPPE_READ_ONLY=1`. A read-only profile
-can still invoke a whitelisted *read* method if you force the verb with
-`frappe-cli api method/… -X GET`.
+This blocks `doc create/update/delete/submit`, `file upload`, and method calls through
+`api`/`method`. Reads such as `doc list/get`, `doctype show`, and `report run` keep
+working.
 
-## Output & scripting
+For environment-variable auth, set `FRAPPE_READ_ONLY=1`. To invoke a whitelisted read
+method, make the safe verb explicit: `frappe-cli api method/… -X GET`.
 
-- On a TTY you get rich tables, colours and confirmation prompts.
-- When piped, or with `--json`, you get clean JSON on stdout and nothing else —
-  pipe it to `jq`. Mutations refuse to run non-interactively without `--yes`.
-- Exit codes: `0` success, `1` failure, `2` usage error. Error detail goes to
-  stderr as plain text (HTML stripped from server messages).
-- `--debug` traces every HTTP request (method, URL, headers with the credential
-  redacted) to stderr, and surfaces server-side SQL for endpoints that expose it
-  (e.g. `doc list`). It never touches stdout, so `--json` output stays clean.
+## Output and scripting
+
+- TTY → rich tables, colours and confirmation prompts.
+- Pipe or `--json` → clean JSON on stdout. Logs and errors stay on stderr, so piping to
+  `jq` is safe.
+- Mutations → refuse to run non-interactively without `--yes`.
+- Exit codes → `0` success, `1` failure, `2` usage error.
+- `--debug` → traces method, URL and headers to stderr. Credentials are redacted. For
+  endpoints that expose it, such as `doc list`, it also prints server-side SQL.
+
+Server error detail is plain text; HTML is stripped. `--debug` never touches stdout, so
+it won't corrupt `--json` output.
 
 ## Commands
 
 | Command | What it does |
 |---|---|
-| `frappe-cli doc list <DocType>` | List documents. `-f` filters, `--fields`, `--limit`, `--all`. |
+| `frappe-cli doc list <DocType>` | List documents. Supports `-f`, `--fields`, `--limit` and `--all`. |
 | `frappe-cli doc get <DocType> <name>` | Fetch one document. |
 | `frappe-cli doc create <DocType>` | Create from `--set` scalars and/or piped/`--input` JSON. |
-| `frappe-cli doc update <DocType> <name>` | Update; optimistic by default, `--force` to override. |
-| `frappe-cli doc delete <DocType> <name>` | Delete (confirms / `--yes`). |
-| `frappe-cli doc submit\|cancel\|amend` | Document lifecycle. |
-| `frappe-cli doctype list` / `frappe-cli doctype show <name>` | Introspection / meta. |
-| `frappe-cli report run <name>` | Run a report with the same filter UX as `list`. |
-| `frappe-cli file upload\|download` | Files, with `--doctype/--name` attach and `--private`. |
-| `frappe-cli api <path>` | Raw v2 access: `frappe-cli api method/<path> -F key=value`. |
-| `frappe-cli guide` | Print a short agent usage primer (no site/auth needed). |
-| `frappe-cli assistant [pi\|claude\|codex]` | Launch a CLI coding agent wired up as a Frappe assistant. |
-| `frappe-cli update` | Self-upgrade via the uv/pip backend it was installed with. |
+| `frappe-cli doc update <DocType> <name>` | Update optimistically; use `--force` to override. |
+| `frappe-cli doc delete <DocType> <name>` | Delete after confirmation, or pass `--yes`. |
+| `frappe-cli doc submit\|cancel\|amend` | Run document lifecycle actions. |
+| `frappe-cli doctype list` / `frappe-cli doctype show <name>` | Discover doctypes and schema. |
+| `frappe-cli report run <name>` | Run a report with the same filter syntax as `doc list`. |
+| `frappe-cli file upload\|download` | Transfer files; upload supports `--doctype/--name` and `--private`. |
+| `frappe-cli api <path>` | Call raw v2 APIs: `frappe-cli api method/<path> -F key=value`. |
+| `frappe-cli guide` | Print the agent primer; no site or authentication needed. |
+| `frappe-cli assistant [pi\|claude\|codex]` | Launch a coding agent configured as a Frappe assistant. |
+| `frappe-cli update` | Self-upgrade through the `uv`/`pip` backend used for installation. |
 
 ### Filtering
 
+Simple filters use `-f`. Repeat the flag to combine them:
+
 ```sh
-frappe-cli doc list ToDo -f status=Open -f 'priority=High'
+frappe-cli doc list ToDo -f status=Open -f priority=High
 frappe-cli doc list "Sales Invoice" -f 'grand_total>1000' -f 'customer like %Inc%'
-# Anything richer (in / between / child tables) → full Frappe filter JSON:
+```
+
+For `in`, `between`, child-table filters or anything else that doesn't fit cleanly in a
+shell argument, pass full Frappe filter JSON:
+
+```sh
 frappe-cli doc list "Sales Invoice" --filters-json '[["status","in",["Paid","Overdue"]]]'
 ```
 


### PR DESCRIPTION
## Summary

- rewrite the README in a direct, engineering-focused voice
- organize documentation around common workflows
- cover authentication, documents, discovery, files, scripting, assistants, and updates

## Verification

- `git diff --check`
- commit hooks, including strict mypy