### PR TITLE
fix: trim guide for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A command-line client for [Frappe](https://frappeframework.com) sites, built for
 humans and AI agents. A pure REST API v2 client for Frappe v16+.
 
-New here (or an agent)? Run `frappe-cli guide` for a one-screen primer covering auth,
+Using an agent? Run `frappe-cli guide` for a one-screen primer covering site access,
 the core verbs, filtering and the raw-API escape hatch.
 
 ```sh
@@ -118,7 +118,7 @@ can still invoke a whitelisted *read* method if you force the verb with
 | `frappe-cli report run <name>` | Run a report with the same filter UX as `list`. |
 | `frappe-cli file upload\|download` | Files, with `--doctype/--name` attach and `--private`. |
 | `frappe-cli api <path>` | Raw v2 access: `frappe-cli api method/<path> -F key=value`. |
-| `frappe-cli guide` | Print a short, self-contained usage primer (no site/auth needed). |
+| `frappe-cli guide` | Print a short agent usage primer (no site/auth needed). |
 | `frappe-cli assistant [pi\|claude\|codex]` | Launch a CLI coding agent wired up as a Frappe assistant. |
 | `frappe-cli update` | Self-upgrade via the uv/pip backend it was installed with. |
 

--- a/src/frappe_cli/commands/guide.py
+++ b/src/frappe_cli/commands/guide.py
@@ -1,51 +1,22 @@
-"""``frappe-cli guide`` — a self-contained usage primer for humans and agents.
+"""``frappe-cli guide`` — a self-contained usage primer for agents.
 
 This is deliberately a single, static, dependency-free command: it needs no
 site, no auth and no network, so an agent can run ``frappe-cli guide`` as its very
-first step to learn the whole surface area before touching a live site.
+first step to learn the CLI surface before touching a live site.
 """
 
 from __future__ import annotations
 
 import typer
 
-GUIDE = r"""frappe-cli — a command-line client for Frappe sites (REST API v2).
+GUIDE = r"""frappe-cli — an agent-friendly client for Frappe REST API v2.
 
-Everything is a thin, scriptable wrapper over the API. On a TTY you get tables
-and colour; when piped or with --json you get clean JSON on stdout and nothing
-else. Exit codes: 0 ok, 1 failure, 2 usage error. Errors go to stderr as plain
-text and usually include a "Tip:" pointing at the command that can help.
+Use --json or pipe output for clean JSON; errors and --debug traces go to stderr.
 
-AUTHENTICATION
-  Credentials are an API key + secret (from User > API Access). They are
-  provided by a human, out of band — this CLI never sets them up for you.
-  Two ways they reach the CLI:
-    1. Env vars (headless / agents) — always win, never touch the keyring:
-         FRAPPE_SITE=https://erp.example.com
-         FRAPPE_API_KEY=xxxx
-         FRAPPE_API_SECRET=yyyy
-    2. Stored profiles (interactive, human-run):
-         frappe-cli auth login https://erp.example.com      # prompts, verifies, stores
-         frappe-cli auth list                                # name, site, description, default
-         frappe-cli auth default <profile>                   # change the default
-         frappe-cli auth configure <profile> --name <new> --description "..."  # rename / describe
-         frappe-cli -s <profile> doc list ToDo               # pick a profile per command
-  A profile's description is a human-written note; in assistant mode read
-  `frappe-cli auth list` to pick the right site by its description.
-  Check who/where you are:  frappe-cli auth whoami
-
-  IF YOU ARE AN AGENT / SCRIPT, credentials are not your job:
-    - Name the site explicitly on every command: pass -s <profile>, or rely on
-      FRAPPE_SITE/FRAPPE_API_KEY/FRAPPE_API_SECRET. When output is piped /
-      non-interactive the configured default profile is only auto-selected if
-      exactly one site is authenticated; with several, a bare command (no -s,
-      no env) will fail rather than guess.
-    - Do NOT set, export or otherwise mutate FRAPPE_SITE / FRAPPE_API_KEY /
-      FRAPPE_API_SECRET (or any FRAPPE_* variable). Read whatever the human
-      already put in the environment; never write to it.
-    - Do NOT run `frappe-cli auth login`. It is interactive-only, refuses a
-      non-TTY, and is a human step. If `frappe-cli auth whoami` fails, STOP and
-      ask the human to authenticate — do not try to work around it.
+SITE ACCESS
+  Access is preconfigured. Pass -s <profile> when a site is specified; with
+  multiple profiles, never guess. Do not run auth commands or modify FRAPPE_*
+  environment variables. If access fails, ask the human to configure it.
 
 ORIENT YOURSELF (do this before guessing field or DocType names)
   frappe-cli doctype list                          # all DocTypes on the site
@@ -64,9 +35,8 @@ DOCUMENTS (CRUD + lifecycle)
   frappe-cli doc delete ToDo abc123 --yes
   frappe-cli doc submit|cancel|amend "Sales Invoice" SINV-0001
 
-FILTERING
-  -f field=value                # repeatable; also >, <, >=, <=, 'like %x%'
-  --filters-json '[["status","in",["Paid","Overdue"]]]'   # full Frappe filter syntax
+  Filters: repeat -f field=value (also >, <, >=, <=, like), or use
+  --filters-json '[["status","in",["Paid","Overdue"]]]'.
 
 REPORTS
   frappe-cli report run "Accounts Receivable" -f company="Frappe" --json
@@ -75,13 +45,12 @@ FILES
   frappe-cli file upload ./contract.pdf --doctype "Sales Invoice" --name SINV-0001 --private
   frappe-cli file download <File name|/files/url> -o out.pdf   # '-o -' streams to stdout
 
-DISCOVER METHODS (find whitelisted API methods before calling them)
+DISCOVER METHODS
   frappe-cli method search --query="unread"          # search path/description/docstring
   frappe-cli method list                              # all methods visible to this session
   frappe-cli method show frappe.tests.test_api.test   # params, http methods, endpoint
-  # Results are session-scoped; requires a Frappe site that supports discovery.
 
-RAW API (the escape hatch for anything the verbs above don't cover)
+RAW API
   frappe-cli api method/frappe.client.get_count -F doctype=User    # -F typed, -f string
   frappe-cli api method/gameplan.api.get_unread_count
   frappe-cli api document/ToDo --method GET
@@ -89,15 +58,11 @@ RAW API (the escape hatch for anything the verbs above don't cover)
   # Background jobs:   frappe-cli doc list "RQ Job"
 
 TIPS FOR AGENTS
-  - Pass --json (or just pipe) for machine-readable output everywhere.
   - Mutations refuse to run non-interactively without --yes.
-  - Debugging? --debug traces each request (and server SQL for `doc list`) to
-    stderr, leaving stdout/--json output clean.
-  - Stuck on a name or field? Run `frappe-cli doctype show <DocType>` first.
   - `frappe-cli <command> --help` documents every flag.
 """
 
 
 def guide() -> None:
-    """Print a short guide to using this CLI (no site or auth required)."""
+    """Print the agent guide to this CLI (no site or auth required)."""
     typer.echo(GUIDE)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,7 +155,7 @@ def test_guide_runs_without_auth():
     # No env / profile configured: guide must still work (no client, no network).
     result = runner.invoke(app, ["guide"])
     assert result.exit_code == 0
-    assert "AUTHENTICATION" in result.stdout
+    assert "SITE ACCESS" in result.stdout
     assert "frappe-cli doctype show" in result.stdout
     assert "frappe-cli api" in result.stdout
 
@@ -163,9 +163,10 @@ def test_guide_runs_without_auth():
 def test_guide_tells_agents_not_to_touch_credentials():
     result = runner.invoke(app, ["guide"])
     assert result.exit_code == 0
-    # The guide must steer agents away from mutating env / auto-login.
-    assert "Do NOT set, export or otherwise mutate" in result.stdout
-    assert "Do NOT run `frappe-cli auth login`" in result.stdout
+    # Authentication is a human concern; the guide only states the boundary.
+    assert "Do not run auth commands" in result.stdout
+    assert "modify FRAPPE_*" in result.stdout
+    assert "auth login" not in result.stdout
 
 
 def test_login_refuses_non_interactive():


### PR DESCRIPTION
## Summary

- make `frappe-cli guide` exclusively agent-focused
- remove human authentication and profile-management instructions
- consolidate repeated output, filtering, discovery, and debugging guidance
- retain the site-access safety boundary and core command coverage

## Tests

- `UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest -q tests/test_cli.py -k guide`
- commit hooks: Ruff, strict mypy, AST and whitespace checks