### PR TITLE
feat(method): discover and invoke doctype methods

### DIFF
--- a/src/frappe_cli/client.py
+++ b/src/frappe_cli/client.py
@@ -12,6 +12,7 @@ import sys
 import time
 from collections.abc import Callable
 from typing import Any, BinaryIO, cast
+from urllib.parse import quote
 
 import httpx
 
@@ -489,6 +490,49 @@ class FrappeClient:
 
     def discovery_show(self, method: str) -> Any:
         return self._discovery_get(f"/api/v2/discovery/method/{method}")
+
+    def discovery_doctype_list(self, doctype: str) -> Any:
+        """List all discoverable methods for one doctype (live introspection).
+
+        Includes both controller-specific and inherited standard methods, so it
+        is not backed by the global discovery cache.
+        """
+        return self._discovery_get(
+            f"/api/v2/discovery/doctype/{quote(doctype, safe='')}"
+        )
+
+    def discovery_doctype_show(self, doctype: str, method: str) -> Any:
+        """Detail document for a single doctype method."""
+        return self._discovery_get(
+            f"/api/v2/discovery/doctype/{quote(doctype, safe='')}"
+            f"/method/{quote(method, safe='')}"
+        )
+
+    def call_document_method(
+        self,
+        doctype: str,
+        name: str,
+        method: str,
+        *,
+        params: dict[str, Any] | None = None,
+        http_method: str = "POST",
+    ) -> Any:
+        """Invoke a whitelisted doctype method against an existing document.
+
+        Targets ``/api/v2/document/{doctype}/{name}/method/{method}`` directly,
+        as advertised by discovery — not the ``run_doc_method`` RPC. Path
+        components are URL-encoded so names containing ``/``, spaces or ``@``
+        are handled correctly.
+        """
+        path = (
+            f"/api/v2/document/{quote(doctype, safe='')}"
+            f"/{quote(name, safe='')}"
+            f"/method/{quote(method, safe='')}"
+        )
+        verb = http_method.upper()
+        if verb == "GET":
+            return self.request("GET", path, params=params)
+        return self.request(verb, path, json_body=params or {})
 
     def discovery_supported(self) -> bool:
         """True if this site exposes method discovery (root is not a 404)."""

--- a/src/frappe_cli/commands/guide.py
+++ b/src/frappe_cli/commands/guide.py
@@ -46,9 +46,14 @@ FILES
   frappe-cli file download <File name|/files/url> -o out.pdf   # '-o -' streams to stdout
 
 DISCOVER METHODS
-  frappe-cli method search --query="unread"          # search path/description/docstring
-  frappe-cli method list                              # all methods visible to this session
-  frappe-cli method show frappe.tests.test_api.test   # params, http methods, endpoint
+  Methods come in two kinds: rpc (a dotted path) and doctype (a controller method
+  run against an existing document). Listings show a `kind` and a unified `ref`.
+  frappe-cli method search --query="unread"           # search across both kinds
+  frappe-cli method list                              # global rpc + doctype index
+  frappe-cli method list --doctype "User"             # methods on one DocType (live)
+  frappe-cli method show frappe.tests.test_api.test   # rpc detail: params, endpoint
+  frappe-cli method show --doctype "User" add_comment # doctype method detail
+  frappe-cli method call "User" Administrator add_comment -F comment_type=Comment
 
 RAW API
   frappe-cli api method/frappe.client.get_count -F doctype=User    # -F typed, -f string

--- a/src/frappe_cli/commands/method.py
+++ b/src/frappe_cli/commands/method.py
@@ -1,15 +1,25 @@
-"""``frappe-cli method`` — discover whitelisted API methods and server scripts.
+"""``frappe-cli method`` — discover and invoke whitelisted API methods.
 
-Backed by Frappe's ``/api/v2/discovery`` endpoints. Results are filtered for the
-current session: guests see guest-accessible methods, authenticated sessions see
-their whitelisted methods, and API server scripts appear only with read
-permission on ``Server Script``.
+Backed by Frappe's ``/api/v2/discovery`` endpoints. Discovery covers two kinds
+of method, distinguished by a ``kind`` field:
+
+- ``rpc`` — a dotted whitelisted function path, invoked via ``/api/v2/method``.
+- ``doctype`` — a whitelisted controller method, invoked against an existing
+  document via ``/api/v2/document/{doctype}/{name}/method/{method}``.
+
+Results are filtered for the current session: guests see guest-accessible
+methods, authenticated sessions see their whitelisted methods, and API server
+scripts appear only with read permission on ``Server Script``. All discovery
+endpoints require the ``System Manager`` role.
 """
 
 from __future__ import annotations
 
+from typing import Any, Optional
+
 import typer
 
+from .. import helpers
 from ..errors import FrappeError
 from ..output import (
     emit_list,
@@ -24,9 +34,31 @@ from ..session import get_client
 
 app = typer.Typer(no_args_is_help=True, help="Discover and inspect API methods.")
 
-# Human-facing messages for the two distinct 404 shapes discovery can produce.
+# Human-facing messages for the distinct 404 shapes discovery can produce.
 _NOT_AVAILABLE = "Method discovery is not available on this site."
 _METHOD_NOT_FOUND = "Method not found or not visible to this session."
+
+
+def _summary_row(entry: Any) -> dict[str, Any]:
+    """Flatten an ``rpc`` | ``doctype`` method summary to a uniform table row.
+
+    Dispatches on ``kind`` before reading kind-specific fields, and folds the
+    two shapes into a single ``ref`` identifier column:
+
+    - ``rpc`` -> the dotted path (``frappe.tests.test_api.test``)
+    - ``doctype`` -> ``Doctype.method`` (``User.populate_role_profile_roles``)
+
+    An unknown/forward-compatible ``kind`` falls back to whatever identifier the
+    entry carries rather than dropping the row.
+    """
+    if not isinstance(entry, dict):
+        return {"kind": None, "ref": str(entry), "description": None}
+    kind = entry.get("kind")
+    if kind == "doctype":
+        ref = f"{entry.get('doctype')}.{entry.get('method')}"
+    else:
+        ref = entry.get("path") or entry.get("method") or ""
+    return {"kind": kind, "ref": ref, "description": entry.get("description")}
 
 
 @app.command("search")
@@ -34,7 +66,7 @@ def search_methods(
     ctx: typer.Context,
     query: str = typer.Option(..., "--query", "-q", help="Search terms."),
 ) -> None:
-    """Search whitelisted methods by type, path, description and docstring."""
+    """Search whitelisted methods by kind, path, doctype, name and docstring."""
     c = get_ctx(ctx)
     client = get_client(c)
     try:
@@ -51,21 +83,42 @@ def search_methods(
     results = result.get("results", []) if isinstance(result, dict) else []
     emit_list(
         c,
-        results,
-        ["path", "type", "allow_guest", "description"],
+        [_summary_row(r) for r in results],
+        ["kind", "ref", "description"],
         title=f"Methods matching {query!r}",
     )
 
 
 @app.command("list")
-def list_methods(ctx: typer.Context) -> None:
+def list_methods(
+    ctx: typer.Context,
+    doctype: Optional[str] = typer.Option(
+        None,
+        "--doctype",
+        help="List methods for one DocType (live: includes inherited standard "
+        "methods) instead of the global RPC + doctype index.",
+    ),
+) -> None:
     """List whitelisted methods visible to the current session."""
     c = get_ctx(ctx)
     client = get_client(c)
     try:
-        result = client.discovery_list()
+        if doctype:
+            result = client.discovery_doctype_list(doctype)
+            title = f"Methods on {doctype}"
+        else:
+            result = client.discovery_list()
+            title = "Methods"
     except FrappeError as e:
         if e.status_code == 404:
+            if doctype:
+                # Doctype listing is live and cache-independent, so a 404 means
+                # the doctype is unknown/undiscoverable (child tables, unknown
+                # names) — unless the whole feature is absent.
+                if client.discovery_supported():
+                    raise fail(
+                        f"DocType {doctype!r} not found or has no discoverable methods."
+                    )
             raise fail(_NOT_AVAILABLE)
         raise fail(e.message)
 
@@ -74,36 +127,20 @@ def list_methods(ctx: typer.Context) -> None:
         return
 
     methods = result.get("methods", []) if isinstance(result, dict) else []
-    emit_list(c, methods, ["path", "allow_guest", "description"], title="Methods")
+    emit_list(
+        c,
+        [_summary_row(m) for m in methods],
+        ["kind", "ref", "description"],
+        title=title,
+    )
 
 
-@app.command("show")
-def show_method(
-    ctx: typer.Context,
-    method: str = typer.Argument(..., help="Method path, e.g. 'frappe.ping'."),
-) -> None:
-    """Show the detailed contract for a single method."""
-    c = get_ctx(ctx)
-    client = get_client(c)
-    try:
-        result = client.discovery_show(method)
-    except FrappeError as e:
-        if e.status_code == 404:
-            # A 404 here is ambiguous: either the whole feature is missing, or
-            # the method is unknown/invisible. Probe the root to disambiguate.
-            if client.discovery_supported():
-                raise fail(_METHOD_NOT_FOUND)
-            raise fail(_NOT_AVAILABLE)
-        raise fail(e.message)
-
-    if c.json:
-        print_json(result)
-        return
-
+def _show_rpc(c: Any, result: Any, method: str) -> None:
     params = result.get("params", []) if isinstance(result, dict) else []
     emit_record(
         c,
         {
+            "kind": "rpc",
             "path": result.get("path"),
             "name": result.get("name"),
             "allow_guest": bool(result.get("allow_guest")),
@@ -113,6 +150,31 @@ def show_method(
         },
         title=f"Method {method}",
     )
+    _emit_params_and_source(c, result, params)
+
+
+def _show_doctype(c: Any, result: Any, doctype: str, method: str) -> None:
+    params = result.get("params", []) if isinstance(result, dict) else []
+    permission = result.get("permission") or {}
+    perm_display = ", ".join(f"{k}={v}" for k, v in permission.items())
+    emit_record(
+        c,
+        {
+            "kind": "doctype",
+            "doctype": result.get("doctype"),
+            "method": result.get("method"),
+            "defined_in": result.get("defined_in"),
+            "http_methods": ", ".join(result.get("http_methods") or []),
+            "permission": perm_display,
+            "endpoint": result.get("endpoint"),
+            "docstring": result.get("docstring"),
+        },
+        title=f"Method {doctype}.{method}",
+    )
+    _emit_params_and_source(c, result, params)
+
+
+def _emit_params_and_source(c: Any, result: Any, params: list[Any]) -> None:
     if params:
         err_console.print("[bold]Parameters[/bold]")
         emit_list(c, params, ["name", "type", "required", "default"])
@@ -120,8 +182,114 @@ def show_method(
         err_console.print("[dim]No parameters.[/dim]")
 
     # Source is present only when the method's app opts in via the
-    # `expose_discovery_source` hook; older sites omit the key entirely.
+    # `expose_discovery_source` hook; other sites omit the key entirely.
     source = result.get("source") if isinstance(result, dict) else None
     if source:
         err_console.print("[bold]Source[/bold]")
         emit_source(source)
+
+
+@app.command("show")
+def show_method(
+    ctx: typer.Context,
+    method: str = typer.Argument(
+        ..., help="RPC path (e.g. 'frappe.ping'), or the method name with --doctype."
+    ),
+    doctype: Optional[str] = typer.Option(
+        None, "--doctype", help="Resolve METHOD as a method on this DocType."
+    ),
+) -> None:
+    """Show the detailed contract for a single method."""
+    c = get_ctx(ctx)
+    client = get_client(c)
+    try:
+        if doctype:
+            result = client.discovery_doctype_show(doctype, method)
+        else:
+            result = client.discovery_show(method)
+    except FrappeError as e:
+        if e.status_code == 404:
+            # A 404 here is ambiguous: either the whole feature is missing, or
+            # the doctype/method is unknown/invisible. Probe the root once to
+            # disambiguate.
+            if client.discovery_supported():
+                raise fail(_METHOD_NOT_FOUND)
+            raise fail(_NOT_AVAILABLE)
+        raise fail(e.message)
+
+    if c.json:
+        print_json(result)
+        return
+
+    if doctype:
+        _show_doctype(c, result, doctype, method)
+    else:
+        _show_rpc(c, result, method)
+
+
+def _pick_verb(http_methods: list[Any]) -> str:
+    """Choose a verb for invoking a doctype method from its advertised set.
+
+    Prefer POST when the method offers it (a ``call`` usually intends to act);
+    otherwise use the single advertised verb, defaulting to POST.
+    """
+    verbs = [str(v).upper() for v in http_methods]
+    if "POST" in verbs:
+        return "POST"
+    return verbs[0] if verbs else "POST"
+
+
+@app.command("call")
+def call_method(
+    ctx: typer.Context,
+    doctype: str = typer.Argument(..., help="DocType, e.g. 'User'."),
+    name: str = typer.Argument(..., help="Existing document name."),
+    method: str = typer.Argument(..., help="Method name, e.g. 'add_comment'."),
+    fields: list[str] = typer.Option(
+        [], "-F", "--field", help="key=value param (typed). Repeatable."
+    ),
+    raw_fields: list[str] = typer.Option(
+        [], "-f", "--raw-field", help="key=value param (always string). Repeatable."
+    ),
+    http_method: Optional[str] = typer.Option(
+        None,
+        "--method",
+        "-X",
+        help="HTTP verb. Default: chosen from the method's detail (POST if offered).",
+    ),
+) -> None:
+    """Invoke a whitelisted doctype method against an existing document."""
+    c = get_ctx(ctx)
+    client = get_client(c)
+
+    params: dict[str, Any] = {}
+    if fields:
+        params.update(helpers.parse_method_params(fields))
+    for item in raw_fields:
+        if "=" not in item:
+            raise fail(f"-f expects key=value, got {item!r}", 2)
+        k, v = item.split("=", 1)
+        params[k.strip()] = v
+
+    verb = http_method.upper() if http_method else None
+    if verb is None:
+        # No explicit verb: consult the detail document to pick GET vs POST.
+        try:
+            detail = client.discovery_doctype_show(doctype, method)
+        except FrappeError as e:
+            if e.status_code == 404:
+                if client.discovery_supported():
+                    raise fail(_METHOD_NOT_FOUND)
+                raise fail(_NOT_AVAILABLE)
+            raise fail(e.message)
+        verb = _pick_verb(
+            detail.get("http_methods") or [] if isinstance(detail, dict) else []
+        )
+
+    try:
+        result = client.call_document_method(
+            doctype, name, method, params=params, http_method=verb
+        )
+    except FrappeError as e:
+        raise fail(e.message)
+    print_json(result)

--- a/src/frappe_cli/commands/method.py
+++ b/src/frappe_cli/commands/method.py
@@ -55,7 +55,7 @@ def _summary_row(entry: Any) -> dict[str, Any]:
         return {"kind": None, "ref": str(entry), "description": None}
     kind = entry.get("kind")
     if kind == "doctype":
-        ref = f"{entry.get('doctype')}.{entry.get('method')}"
+        ref = f"{entry.get('doctype') or ''}.{entry.get('method') or ''}"
     else:
         ref = entry.get("path") or entry.get("method") or ""
     return {"kind": kind, "ref": ref, "description": entry.get("description")}

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -199,6 +199,256 @@ def test_method_show_omits_source_section_when_absent(env, monkeypatch):
     assert "Source" not in result.output
 
 
+# --- unified index / tagged union ----------------------------------------
+
+
+@respx.mock
+def test_method_list_renders_both_kinds_human(env, monkeypatch):
+    _force_human_output(monkeypatch)
+    respx.get(f"{BASE}/api/v2/discovery/method").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "type": "method_index",
+                    "methods": [
+                        {
+                            "kind": "rpc",
+                            "path": "frappe.tests.test_api.test",
+                            "description": "Exercise RPC.",
+                        },
+                        {
+                            "kind": "doctype",
+                            "doctype": "User",
+                            "method": "populate_role_profile_roles",
+                        },
+                    ],
+                }
+            },
+        )
+    )
+    result = runner.invoke(app, ["method", "list"])
+    assert result.exit_code == 0
+    # RPC ref is the dotted path; doctype ref is Doctype.method.
+    assert "frappe.tests.test_api.test" in result.output
+    assert "User.populate_role_profile_roles" in result.output
+
+
+@respx.mock
+def test_method_search_renders_doctype_kind(env, monkeypatch):
+    _force_human_output(monkeypatch)
+    respx.get(f"{BASE}/api/v2/discovery/search").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "results": [
+                        {
+                            "kind": "doctype",
+                            "doctype": "User",
+                            "method": "populate_role_profile_roles",
+                            "description": "First line.",
+                        }
+                    ]
+                }
+            },
+        )
+    )
+    result = runner.invoke(
+        app, ["method", "search", "-q", "User populate_role_profile_roles"]
+    )
+    assert result.exit_code == 0
+    assert "doctype" in result.output
+    assert "User.populate_role_profile_roles" in result.output
+
+
+# --- doctype-scoped listing & detail --------------------------------------
+
+
+@respx.mock
+def test_method_list_doctype_hits_scoped_endpoint(env):
+    route = respx.get(f"{BASE}/api/v2/discovery/doctype/User").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "type": "method_index",
+                    "doctype": "User",
+                    "methods": [
+                        {"kind": "doctype", "doctype": "User", "method": "add_comment"}
+                    ],
+                }
+            },
+        )
+    )
+    result = runner.invoke(app, ["--json", "method", "list", "--doctype", "User"])
+    assert result.exit_code == 0
+    assert route.called
+    assert "add_comment" in result.stdout
+
+
+@respx.mock
+def test_method_list_doctype_url_encodes_name(env):
+    route = respx.get(f"{BASE}/api/v2/discovery/doctype/Sales%20Invoice").mock(
+        return_value=httpx.Response(
+            200, json={"data": {"type": "method_index", "methods": []}}
+        )
+    )
+    result = runner.invoke(
+        app, ["--json", "method", "list", "--doctype", "Sales Invoice"]
+    )
+    assert result.exit_code == 0
+    assert route.called
+
+
+@respx.mock
+def test_method_list_doctype_404_when_supported_reports_unknown(env):
+    respx.get(f"{BASE}/api/v2/discovery/doctype/Nope").mock(
+        return_value=httpx.Response(404)
+    )
+    respx.get(f"{BASE}/api/v2/discovery").mock(
+        return_value=httpx.Response(200, json={"data": {"type": "discovery"}})
+    )
+    result = runner.invoke(app, ["--json", "method", "list", "--doctype", "Nope"])
+    assert result.exit_code == 1
+    assert "not found or has no discoverable methods" in result.stderr
+
+
+@respx.mock
+def test_method_show_doctype_detail_json(env):
+    respx.get(f"{BASE}/api/v2/discovery/doctype/User/method/add_comment").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "type": "method",
+                    "kind": "doctype",
+                    "doctype": "User",
+                    "method": "add_comment",
+                    "defined_in": "frappe.model.document.Document",
+                    "endpoint": "/api/v2/document/User/{name}/method/add_comment",
+                    "http_methods": ["GET", "POST"],
+                    "permission": {"GET": "read", "POST": "write"},
+                    "params": [],
+                }
+            },
+        )
+    )
+    result = runner.invoke(
+        app, ["--json", "method", "show", "--doctype", "User", "add_comment"]
+    )
+    assert result.exit_code == 0
+    assert "frappe.model.document.Document" in result.stdout
+
+
+@respx.mock
+def test_method_show_doctype_detail_human_shows_defined_in(env, monkeypatch):
+    _force_human_output(monkeypatch)
+    respx.get(f"{BASE}/api/v2/discovery/doctype/User/method/add_comment").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "kind": "doctype",
+                    "doctype": "User",
+                    "method": "add_comment",
+                    "defined_in": "frappe.model.document.Document",
+                    "http_methods": ["GET", "POST"],
+                    "permission": {"GET": "read", "POST": "write"},
+                    "params": [
+                        {"name": "comment_type", "required": False, "type": "str"}
+                    ],
+                }
+            },
+        )
+    )
+    result = runner.invoke(app, ["method", "show", "--doctype", "User", "add_comment"])
+    assert result.exit_code == 0
+    assert "defined_in" in result.output
+    assert "comment_type" in result.output
+
+
+# --- invocation -----------------------------------------------------------
+
+
+@respx.mock
+def test_method_call_picks_post_and_invokes_document_endpoint(env):
+    respx.get(f"{BASE}/api/v2/discovery/doctype/User/method/add_comment").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "kind": "doctype",
+                    "doctype": "User",
+                    "method": "add_comment",
+                    "http_methods": ["GET", "POST"],
+                }
+            },
+        )
+    )
+    invoke = respx.post(
+        f"{BASE}/api/v2/document/User/Administrator/method/add_comment"
+    ).mock(return_value=httpx.Response(200, json={"data": {"name": "c1"}}))
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "method",
+            "call",
+            "User",
+            "Administrator",
+            "add_comment",
+            "-F",
+            "comment_type=Comment",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    assert invoke.called
+    import json as _json
+
+    assert _json.loads(invoke.calls.last.request.content)["comment_type"] == "Comment"
+
+
+@respx.mock
+def test_method_call_explicit_get_skips_detail_fetch(env):
+    detail = respx.get(
+        f"{BASE}/api/v2/discovery/doctype/User/method/get_something"
+    ).mock(return_value=httpx.Response(200, json={"data": {}}))
+    invoke = respx.get(
+        f"{BASE}/api/v2/document/User/Administrator/method/get_something"
+    ).mock(return_value=httpx.Response(200, json={"data": {"ok": 1}}))
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "method",
+            "call",
+            "User",
+            "Administrator",
+            "get_something",
+            "-X",
+            "GET",
+        ],
+    )
+    assert result.exit_code == 0
+    assert invoke.called
+    # With an explicit verb we don't need to consult discovery detail.
+    assert not detail.called
+
+
+@respx.mock
+def test_method_call_url_encodes_document_name(env):
+    invoke = respx.post(
+        f"{BASE}/api/v2/document/User/a%2Fb%40x/method/add_comment"
+    ).mock(return_value=httpx.Response(200, json={"data": {}}))
+    result = runner.invoke(
+        app,
+        ["--json", "method", "call", "User", "a/b@x", "add_comment", "-X", "POST"],
+    )
+    assert result.exit_code == 0
+    assert invoke.called
+
+
 @respx.mock
 def test_method_show_json_preserved_after_503_retry(env):
     respx.get(f"{BASE}/api/v2/discovery/method/frappe.ping").mock(


### PR DESCRIPTION
## What

API v2 discovery now exposes whitelisted document-controller methods alongside RPC methods, sharing the method index and search endpoint. Each entry carries a `kind` discriminator (`"rpc"` | `"doctype"`), so the method index and search are now a tagged union — clients can no longer assume every entry has a dotted `path`. This extends `frappe-cli method` to cover the new surface.

## Changes

- **Tagged-union parsing** — `method list` and `method search` handle both summary shapes and fold them into a single `kind`/`ref` column (RPC → dotted path, doctype → `Doctype.method`). The `allow_guest` column is dropped, since summaries no longer carry it. Unknown/forward-compatible kinds fall back to whatever identifier they carry rather than dropping the row.
- **`method list --doctype DT`** — lists a doctype's methods via the live, scoped `/discovery/doctype/{doctype}` endpoint, which includes inherited standard methods and is independent of the global discovery cache.
- **`method show --doctype DT METHOD`** — resolves doctype method detail via `/discovery/doctype/{doctype}/method/{method}`, surfacing `defined_in` and the GET/POST permission map.
- **`method call DT NAME METHOD -F k=v [-X VERB]`** — invokes a doctype method against an existing document. The verb defaults from the detail document (POST when offered), overridable with `-X`; the request targets `/api/v2/document/{dt}/{name}/method/{method}` — not `run_doc_method`.
- Path components are URL-encoded, so names with spaces, `/` or `@` are handled correctly.
- The existing 503 cold-cache retry and `data`-envelope unwrapping cover the new endpoints unchanged.
- Guide text updated to document both kinds and the new commands.

## Testing

- 51 unit tests pass (10 new: union rendering, scoped list/detail, URL encoding, invocation verb selection); ruff + mypy strict clean.
- Verified end-to-end against a live Frappe v15 site: root advertises `doctype_methods`; global search returns a `kind=doctype` result for `User populate_role_profile_roles`; `show --doctype User add_comment` returns `defined_in=frappe.model.document.Document` with the permission map; and `method call` created a real Comment via `POST /api/v2/document/ToDo/.../method/add_comment` (confirmed with `--debug`).