### PR TITLE
feat(api): structured -F values (key:=json), fix GET --input

### DIFF
--- a/src/frappectl/commands/api.py
+++ b/src/frappectl/commands/api.py
@@ -35,7 +35,10 @@ def api(
         help="API path, e.g. 'method/frappe.client.get_count' or 'document/User'.",
     ),
     fields: list[str] = typer.Option(
-        [], "-F", "--field", help="key=value param (typed). Repeatable."
+        [],
+        "-F",
+        "--field",
+        help="key=value (typed scalar) or key:=value (raw JSON). Repeatable.",
     ),
     raw_fields: list[str] = typer.Option(
         [], "-f", "--raw-field", help="key=value param (always string). Repeatable."
@@ -75,6 +78,17 @@ def api(
             raise fail(f"Could not read --input: {e}", 2)
 
     http_method = (method or ("POST" if body is not None else "GET")).upper()
+
+    # A GET has no body, so --input on a GET only makes sense as query
+    # parameters. Merge its top-level keys into the query alongside -F/-f.
+    if http_method == "GET" and body is not None:
+        if not isinstance(body, dict):
+            raise fail(
+                "--input for a GET request must be a JSON object; its keys are "
+                "sent as query parameters.",
+                2,
+            )
+        params.update(body)
 
     clean_path = path.lstrip("/")
     if clean_path.startswith("api/v2/"):

--- a/src/frappectl/commands/guide.py
+++ b/src/frappectl/commands/guide.py
@@ -58,6 +58,7 @@ DISCOVER METHODS
 
 RAW API
   frappectl api method/frappe.client.get_count -F doctype=User    # -F typed, -f string
+  frappectl api method/frappe.client.get_list -F doctype=User -F 'filters:={"enabled":1}'  # :=  raw JSON
   frappectl api method/gameplan.api.get_unread_count
   frappectl api document/ToDo --method GET
   # Workflow actions: frappectl api method/frappe.model.workflow.apply_workflow

--- a/src/frappectl/commands/method.py
+++ b/src/frappectl/commands/method.py
@@ -263,7 +263,10 @@ def call_method(
         None, "--name", help="Existing document name. Required with --doctype."
     ),
     fields: list[str] = typer.Option(
-        [], "-F", "--field", help="key=value param (typed). Repeatable."
+        [],
+        "-F",
+        "--field",
+        help="key=value (typed scalar) or key:=value (raw JSON). Repeatable.",
     ),
     raw_fields: list[str] = typer.Option(
         [], "-f", "--raw-field", help="key=value param (always string). Repeatable."

--- a/src/frappectl/helpers.py
+++ b/src/frappectl/helpers.py
@@ -114,8 +114,48 @@ def parse_set(assignments: list[str]) -> dict[str, Any]:
 
 
 def parse_method_params(params: list[str]) -> dict[str, Any]:
-    """Parse gh-style ``-F key=value`` method parameters."""
-    return parse_set(params)
+    """Parse gh-style ``-F`` params into a dict of typed values.
+
+    Two forms are supported per token:
+
+    * ``key=value`` — best-effort scalar coercion (numbers, booleans, ``null``,
+      otherwise a string), matching ``--set`` / filter values::
+
+          -F limit=100          # int 100
+          -F unread=true        # bool True
+
+    * ``key:=value`` — ``value`` is parsed as raw JSON, so objects and arrays
+      pass through structurally::
+
+          -F filter:='{"inMailbox":"a"}'
+          -F emails:='["a@example.com","b@example.com"]'
+
+    Structured values are sent as native JSON in a request body and JSON-encoded
+    into the query string for GET requests (see :func:`_clean_params` in the
+    transport layer), so the same ``-F`` behaves identically either way.
+    """
+    out: dict[str, Any] = {}
+    for item in params:
+        eq = item.find("=")
+        if eq < 1:
+            raise UsageError(f"-F expects key=value or key:=value, got {item!r}")
+        if item[eq - 1] == ":":
+            key = item[: eq - 1].strip()
+            raw = item[eq + 1 :]
+            if not key:
+                raise UsageError(f"-F expects key:=value, got {item!r}")
+            try:
+                out[key] = json.loads(raw)
+            except json.JSONDecodeError as e:
+                raise UsageError(
+                    f"-F {key}:= expects a JSON value, got {raw!r}: {e}"
+                ) from e
+        else:
+            key = item[:eq].strip()
+            if not key:
+                raise UsageError(f"-F expects key=value, got {item!r}")
+            out[key] = _coerce(item[eq + 1 :])
+    return out
 
 
 def default_fields(meta: dict[str, Any]) -> list[str]:

--- a/src/frappectl/transport.py
+++ b/src/frappectl/transport.py
@@ -422,7 +422,16 @@ def _clean_params(
 ) -> dict[str, Any] | None:
     if not params:
         return params
-    return {k: v for k, v in params.items() if v is not None}
+    cleaned: dict[str, Any] = {}
+    for k, v in params.items():
+        if v is None:
+            continue
+        # httpx serializes scalars (and bool/None) for a query string but not
+        # nested containers. Frappe expects those as JSON strings anyway
+        # (filters, structured -F values), so encode dicts/lists here. Values
+        # already stringified upstream (e.g. json.dumps'd filters) pass through.
+        cleaned[k] = json.dumps(v) if isinstance(v, (dict, list)) else v
+    return cleaned
 
 
 def _safe_json(resp: httpx.Response) -> Any:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,3 +336,83 @@ def test_api_method_get(env):
     )
     assert result.exit_code == 0
     assert result.stdout.strip() == "5"
+
+
+@respx.mock
+def test_api_get_structured_field_json_encodes_query(env):
+    route = respx.get(f"{BASE}/api/v2/method/frappe.client.get_list").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    result = runner.invoke(
+        app,
+        [
+            "api",
+            "method/frappe.client.get_list",
+            "-F",
+            "doctype=User",
+            "-F",
+            'filters:={"enabled":1}',
+            "-F",
+            'or_filters:=[["a","=","b"]]',
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    q = route.calls.last.request.url.params
+    # Scalars go through plainly; containers are JSON-encoded on the wire.
+    assert q["doctype"] == "User"
+    assert q["filters"] == '{"enabled": 1}'
+    assert q["or_filters"] == '[["a", "=", "b"]]'
+
+
+@respx.mock
+def test_api_post_structured_field_native_json_body(env):
+    route = respx.post(f"{BASE}/api/v2/method/some.method").mock(
+        return_value=httpx.Response(200, json={"data": "ok"})
+    )
+    result = runner.invoke(
+        app,
+        [
+            "api",
+            "method/some.method",
+            "-X",
+            "POST",
+            "-F",
+            'emails:=["a@example.com","b@example.com"]',
+            "-F",
+            "limit=10",
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    import json as _json
+
+    body = _json.loads(route.calls.last.request.content)
+    # Same -F, but in a body the structure is native JSON, not a string.
+    assert body == {"emails": ["a@example.com", "b@example.com"], "limit": 10}
+
+
+@respx.mock
+def test_api_get_with_input_sends_body_keys_as_query(env):
+    route = respx.get(f"{BASE}/api/v2/method/frappe.client.get_count").mock(
+        return_value=httpx.Response(200, json={"data": 2})
+    )
+    result = runner.invoke(
+        app,
+        ["api", "method/frappe.client.get_count", "-X", "GET", "--input", "-"],
+        input='{"doctype": "User", "filters": {"enabled": 1}}',
+    )
+    assert result.exit_code == 0, result.stderr
+    assert route.called
+    q = route.calls.last.request.url.params
+    assert q["doctype"] == "User"
+    assert q["filters"] == '{"enabled": 1}'
+
+
+@respx.mock
+def test_api_get_with_non_object_input_errors(env):
+    result = runner.invoke(
+        app,
+        ["api", "method/frappe.ping", "-X", "GET", "--input", "-"],
+        input="[1, 2, 3]",
+    )
+    assert result.exit_code == 2
+    assert "must be a JSON object" in result.stderr

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -54,6 +54,51 @@ def test_parse_set_bad():
         helpers.parse_set(["nope"])
 
 
+def test_parse_method_params_scalars():
+    assert helpers.parse_method_params(["limit=100", "unread=true", "name=x"]) == {
+        "limit": 100,
+        "unread": True,
+        "name": "x",
+    }
+
+
+def test_parse_method_params_json_values():
+    # ``key:=value`` parses the value as raw JSON: objects and arrays pass
+    # through structurally rather than being flattened to a string.
+    assert helpers.parse_method_params(
+        [
+            'filter:={"inMailbox":"a"}',
+            'emails:=["a@example.com","b@example.com"]',
+            "count:=3",
+            "flag:=false",
+            "nothing:=null",
+        ]
+    ) == {
+        "filter": {"inMailbox": "a"},
+        "emails": ["a@example.com", "b@example.com"],
+        "count": 3,
+        "flag": False,
+        "nothing": None,
+    }
+
+
+def test_parse_method_params_scalar_with_colon_in_value():
+    # A ``:`` inside the value (not immediately before ``=``) stays a scalar.
+    assert helpers.parse_method_params(["ts=2026-07-17T10:00:00"]) == {
+        "ts": "2026-07-17T10:00:00"
+    }
+
+
+def test_parse_method_params_bad_json():
+    with pytest.raises(UsageError):
+        helpers.parse_method_params(["filter:={not json}"])
+
+
+def test_parse_method_params_missing_equals():
+    with pytest.raises(UsageError):
+        helpers.parse_method_params(["nope"])
+
+
 def test_parse_fields():
     assert helpers.parse_fields("a,b, c") == ["a", "b", "c"]
     assert helpers.parse_fields("*") == ["*"]


### PR DESCRIPTION
## What

`-F` was documented as "typed" but only coerced scalars — there was no way to pass an object or array without falling back to `--input` and hand-building a body. Adopt the `gh`/httpie split:

```sh
frappectl api method/frappe.client.get_list \
  -F doctype=User \
  -F 'filters:={"enabled":1}' \      # := → value parsed as raw JSON
  -F 'fields:=["name","enabled"]'
```

| Form | Value | Result |
|------|-------|--------|
| `-F limit=100` | `100` | typed scalar (int) — unchanged |
| `-F unread=true` | `true` | `bool` — unchanged |
| `-F filter:='{"inMailbox":"a"}'` | JSON object | `{"inMailbox": "a"}` |
| `-F emails:='["a@x","b@x"]'` | JSON array | `["a@x", "b@x"]` |

Also fixes a concrete raw-API bug: **`--input … -X GET` read the body and then dropped it.**

## Why

`-F` claiming to be "typed" while silently flattening everything to a scalar is a footgun — you'd write `-F filters:=…`-shaped calls expecting structure and get a string, or not be able to express it at all. This closes the gap so the raw-API escape hatch can express any whitelisted-method call without dropping to `--input`.

## How

- **Parsing** (`helpers.parse_method_params`): `key=value` keeps best-effort scalar coercion; `key:=value` parses the value as raw JSON. Bad JSON / missing `=` now raise a clear `-F`-specific usage error instead of leaking the old `--set expects…` message. Shared by `frappectl api` and `frappectl method call`, so both get it. `_coerce`/`parse_set` are untouched — `--set` and `-f` filters are unaffected.
- **Wire consistency** (`transport._clean_params`): the *same* `-F` behaves the same either way — native JSON in a request body, and JSON-encoded into the query string for GET. httpx can't serialize nested containers into a query string (dicts raise; lists become repeated keys — neither is what Frappe wants), so dict/list values are `json.dumps`'d there. Values already stringified upstream (e.g. `doc list` filters) are strings and pass straight through — no double-encoding.

## Symptom → Diagnosis → Fix (the GET bug)

- **Symptom:** `echo '{"doctype":"User"}' | frappectl api method/frappe.client.get_count -X GET --input -` ran, but the input never reached the server — you got the unfiltered count.
- **Diagnosis:** a GET has no body. The code read `--input` into `body`, but the GET branch only sent `-F`/`-f` params, so the body's keys were silently dropped. ← the bug
- **Fix:** on a GET, `--input`'s top-level keys are merged into the query string alongside `-F`/`-f`. A non-object `--input` on a GET is rejected with exit 2 and a clear message.

## Tests

- `parse_method_params`: scalar vs `:=` JSON, `:` inside a scalar value (`ts=2026-07-17T10:00:00` stays a string), bad JSON, missing `=`.
- `api` command: GET query JSON-encodes containers; POST body keeps them native; GET `--input` sends body keys as query params; non-object GET `--input` errors.
- Full suite: 220 passed, 14 skipped. mypy clean.

## Manual verification (dev.localhost)

Run with `--debug` — it prints the outgoing request line so you can see the query/body directly.

```sh
# structured := in a GET query (encoded as JSON strings)
frappectl --debug api method/frappe.client.get_list \
  -F doctype=User -F 'filters:={"enabled":1}' -F 'fields:=["name"]'

# same -F in a POST body (native JSON, not a string)
frappectl --debug api method/frappe.client.get_list -X POST \
  -F doctype=User -F 'filters:={"enabled":1}'

# the GET --input fix
echo '{"doctype":"User","filters":{"enabled":1}}' \
  | frappectl --debug api method/frappe.client.get_count -X GET --input -
```
