### PR TITLE
fix(guide): drop the "mutations run without confirmation" tip

### DIFF
--- a/src/frappectl/commands/guide.py
+++ b/src/frappectl/commands/guide.py
@@ -61,12 +61,6 @@ RAW API
   frappectl api method/frappe.client.get_list -F doctype=User -F 'filters:={"enabled":1}'  # :=  raw JSON
   frappectl api method/gameplan.api.get_unread_count
   frappectl api document/ToDo --method GET
-  # Workflow actions: frappectl api method/frappe.model.workflow.apply_workflow
-  # Background jobs:   frappectl doc list "RQ Job"
-
-TIPS FOR AGENTS
-  - Mutations (delete, cancel, update) run immediately, with no confirmation prompt.
-  - `frappectl <command> --help` documents every flag.
 """
 
 


### PR DESCRIPTION
It read as license to mutate freely rather than a caution, and is
prone to accidents. Closes #46.

Co-authored-by: Pratham Sharma <66195934+ps173@users.noreply.github.com>
