### PR TITLE
feat: prefer the QUERY HTTP verb for reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ A read-only profile refuses every unsafe HTTP method **before the request leaves
 machine**. This removes the obvious production footgun: an exploratory command can't
 accidentally mutate the site.
 
+On servers that support it, reads are sent with the
+[QUERY](https://github.com/frappe/frappe/pull/41135) HTTP verb instead of GET: params
+travel as a native JSON body rather than a length-limited query string, and the server
+rolls back the transaction at the end of the request — so for read-only profiles the
+guarantee no longer rests on every endpoint being well-behaved. Servers that don't
+accept QUERY transparently fall back to plain GET.
+
 ```sh
 frappectl auth login https://prod.example.com --name prod --read-only
 frappectl auth configure prod --read-only             # lock an existing profile

--- a/src/frappectl/resources.py
+++ b/src/frappectl/resources.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import time
 from typing import Any, BinaryIO, cast
 
@@ -36,9 +35,9 @@ class DocumentsAPI:
     ) -> tuple[list[Document], bool]:
         params: dict[str, Any] = {"start": start, "limit": limit}
         if fields:
-            params["fields"] = json.dumps(fields)
+            params["fields"] = fields
         if filters:
-            params["filters"] = json.dumps(filters)
+            params["filters"] = filters
         if order_by:
             params["order_by"] = order_by
         if self._transport.debug:
@@ -111,11 +110,10 @@ class DocumentsAPI:
         )
 
     def count(self, doctype: str, filters: Filters | None = None) -> int:
-        params = {"filters": json.dumps(filters)} if filters else None
+        params = {"filters": filters} if filters else None
         return cast(
             int,
-            self._transport.request(
-                "GET",
+            self._transport.request_read(
                 endpoint_path("api", "v2", "doctype", doctype, "count"),
                 params=params,
             ),
@@ -136,7 +134,7 @@ class MethodsAPI:
         path = endpoint_path("api", "v2", "method", method)
         verb = http_method.upper()
         if verb == "GET":
-            return self._transport.request("GET", path, params=params)
+            return self._transport.request_read(path, params=params)
         return self._transport.request(verb, path, json_body=params or {})
 
     def call_document(
@@ -151,7 +149,7 @@ class MethodsAPI:
         path = endpoint_path("api", "v2", "document", doctype, name, "method", method)
         verb = http_method.upper()
         if verb == "GET":
-            return self._transport.request("GET", path, params=params)
+            return self._transport.request_read(path, params=params)
         return self._transport.request(verb, path, json_body=params or {})
 
     def logged_user(self) -> str:

--- a/src/frappectl/transport.py
+++ b/src/frappectl/transport.py
@@ -32,8 +32,17 @@ DISCOVERY_FALLBACK_BACKOFF = 2.0
 _DEBUG_BODY_LIMIT = 2000
 
 # HTTP methods that never mutate server state. A read-only profile is allowed
-# exactly these; anything else is refused before it reaches the wire.
-_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+# exactly these; anything else is refused before it reaches the wire. QUERY
+# (GET-like transaction semantics with a POST-like body; frappe/frappe#41135)
+# is safe: the server rolls the transaction back at the end of the request.
+_SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "QUERY"}
+
+# Responses that mean "this server/route does not speak QUERY" rather than
+# "the request failed": routing rejects the verb (405/501, or 404 behind some
+# proxies), and pre-QUERY whitelisting rejects it with a PermissionError (403).
+# A genuine failure with one of these statuses fails the GET fallback too, so
+# falling back never masks a real error — it only costs one extra request.
+_QUERY_FALLBACK_STATUSES = {403, 404, 405, 501}
 
 
 def _auth_header(token_type: str, token: str) -> str:
@@ -86,6 +95,9 @@ class FrappeTransport:
         self.site = str(site_url)
         self.debug = debug
         self.read_only = read_only
+        # Whether the server accepts the QUERY verb. Unknown until a read on a
+        # QUERY-mounted route settles it; None means "keep trying QUERY".
+        self._query_supported: bool | None = None
         if credential_provider is None:
             if token_type == "bearer":
                 credential_provider = _LegacyBearerProvider(token, on_unauthorized)
@@ -261,6 +273,49 @@ class FrappeTransport:
         )
         return self.handle_response(resp)
 
+    def request_read(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
+        """Make a GET-shaped read and return the unwrapped ``data`` payload.
+
+        Prefers the QUERY verb; see :meth:`send_read`.
+        """
+        return self.handle_response(self.send_read(path, params=params))
+
+    def send_read(
+        self, path: str, *, params: dict[str, Any] | None = None
+    ) -> httpx.Response:
+        """Send one read request, preferring the QUERY verb over GET.
+
+        QUERY is GET with a request body: params travel as native JSON instead
+        of a length-limited JSON-in-query-string encoding, and the server
+        rolls the transaction back at the end of the request — which is
+        exactly the guarantee a read-only profile wants, enforced server-side
+        rather than by trusting every endpoint to be well-behaved. Servers
+        that don't speak QUERY get a GET fallback, and the outcome is
+        remembered so only the first read pays the probe.
+
+        Only routes that mount QUERY (document lists, count, RPC and
+        doc-method calls) should come through here: a GET-only route would
+        probe uselessly and could teach ``_query_supported`` the wrong answer.
+        """
+        if self._query_supported is False:
+            return self.send("GET", path, params=_clean_params(params))
+
+        try:
+            resp = self._send("QUERY", path, json=_clean_body(params))
+        except httpx.HTTPError as e:
+            raise FrappeError(f"Could not reach {self.site}: {e}") from e
+        if resp.status_code not in _QUERY_FALLBACK_STATUSES:
+            if resp.status_code < 400:
+                self._query_supported = True
+            return resp
+
+        fallback = self.send("GET", path, params=_clean_params(params))
+        # Only a fallback that *succeeds* proves QUERY itself was the problem;
+        # when both fail (e.g. a genuine 403) the next read probes again.
+        if fallback.status_code < 400 and self._query_supported is None:
+            self._query_supported = False
+        return fallback
+
     def request_read_only_post(self, path: str, *, json_body: Any) -> Any:
         """POST to an endpoint whose server-side contract guarantees no writes.
 
@@ -279,7 +334,7 @@ class FrappeTransport:
         if self.read_only and method.upper() not in _SAFE_METHODS:
             raise FrappeError(
                 f"Refusing to send a {method.upper()} request: this profile is "
-                "read-only. Only GET, HEAD, and OPTIONS requests are permitted. Use a "
+                "read-only. Only GET, HEAD, OPTIONS, and QUERY requests are permitted. Use a "
                 "writable profile, or pass -X GET for a whitelisted read method."
             )
         try:
@@ -376,10 +431,7 @@ class FrappeTransport:
         self, path: str, *, params: dict[str, Any] | None = None
     ) -> tuple[list[Document], bool]:
         """Return a paginated response without discarding its page marker."""
-        try:
-            resp = self._send("GET", path, params=_clean_params(params))
-        except httpx.HTTPError as e:
-            raise FrappeError(f"Could not reach {self.site}: {e}") from e
+        resp = self.send_read(path, params=params)
         if resp.status_code >= 400:
             body = _safe_json(resp)
             raise self._server_error(
@@ -392,10 +444,13 @@ class FrappeTransport:
 
     def request_envelope_data(self, method: str, path: str) -> Any:
         """Return data only when the server sent a trusted JSON envelope."""
-        try:
-            resp = self._send(method, path)
-        except httpx.HTTPError as e:
-            raise FrappeError(f"Could not reach {self.site}: {e}") from e
+        if method.upper() == "GET":
+            resp = self.send_read(path)
+        else:
+            try:
+                resp = self._send(method, path)
+            except httpx.HTTPError as e:
+                raise FrappeError(f"Could not reach {self.site}: {e}") from e
         self._handle(resp)
         body = _safe_json(resp)
         if isinstance(body, dict) and "data" in body:
@@ -445,6 +500,17 @@ def _clean_params(
         # already stringified upstream (e.g. json.dumps'd filters) pass through.
         cleaned[k] = json.dumps(v) if isinstance(v, (dict, list)) else v
     return cleaned
+
+
+def _clean_body(params: dict[str, Any] | None) -> dict[str, Any]:
+    """Params as a QUERY JSON body: drop Nones, keep native containers.
+
+    The server parses the body like a POST form, so containers go over the
+    wire as JSON values instead of the JSON-in-query-string encoding GET needs.
+    """
+    if not params:
+        return {}
+    return {k: v for k, v in params.items() if v is not None}
 
 
 def _safe_json(resp: httpx.Response) -> Any:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import pytest
 import respx
@@ -66,17 +68,16 @@ def test_doc_list_meta_driven_fields(env):
             },
         )
     )
-    list_route = respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+    list_route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
         return_value=httpx.Response(
             200, json={"data": [{"name": "a"}], "has_next_page": False}
         )
     )
     result = runner.invoke(app, ["--json", "doc", "list", "ToDo"])
     assert result.exit_code == 0
-    assert "fields" in list_route.calls.last.request.url.params
-    fields = list_route.calls.last.request.url.params["fields"]
-    assert "description" in fields and "status" in fields
-    assert list_route.calls.last.request.url.params["order_by"] == "creation desc"
+    body = json.loads(list_route.calls.last.request.content)
+    assert "description" in body["fields"] and "status" in body["fields"]
+    assert body["order_by"] == "creation desc"
 
 
 @respx.mock
@@ -208,7 +209,7 @@ def test_oauth_flag_skips_authentication_choice(monkeypatch):
 
 @respx.mock
 def test_get_logged_user_only_trusts_non_guest_data():
-    route = respx.get(f"{BASE}/api/v2/method/frappe.auth.get_logged_user")
+    route = respx.request("QUERY", f"{BASE}/api/v2/method/frappe.auth.get_logged_user")
     with FrappeClient(BASE, "k:s") as client:
         route.mock(return_value=httpx.Response(200, json={"data": "user@example.com"}))
         assert client.get_logged_user() == "user@example.com"
@@ -283,7 +284,7 @@ def test_error_includes_hint(env):
 
 @respx.mock
 def test_server_exception_nudges_debug(env):
-    respx.get(f"{BASE}/api/v2/method/x.y").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/method/x.y").mock(
         return_value=httpx.Response(
             500,
             json={"errors": [{"exception": "Traceback...\nKeyError: 'z'"}]},
@@ -297,7 +298,7 @@ def test_server_exception_nudges_debug(env):
 
 @respx.mock
 def test_no_debug_nudge_under_debug(env):
-    respx.get(f"{BASE}/api/v2/method/x.y").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/method/x.y").mock(
         return_value=httpx.Response(
             500,
             json={"errors": [{"exception": "Traceback...\nKeyError: 'z'"}]},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import pytest
 import respx
@@ -14,7 +16,7 @@ def client():
 
 @respx.mock
 def test_list_documents():
-    respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
         return_value=httpx.Response(
             200, json={"data": [{"name": "a"}, {"name": "b"}], "has_next_page": True}
         )
@@ -68,7 +70,7 @@ def test_401_message():
 
 @respx.mock
 def test_call_method_get():
-    respx.get(f"{BASE}/api/v2/method/frappe.client.get_count").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/method/frappe.client.get_count").mock(
         return_value=httpx.Response(200, json={"data": 42})
     )
     assert (
@@ -133,7 +135,7 @@ def test_stream_download_raises_on_error():
 
 @respx.mock
 def test_count():
-    respx.get(f"{BASE}/api/v2/doctype/ToDo/count").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/doctype/ToDo/count").mock(
         return_value=httpx.Response(200, json={"data": 7})
     )
     assert client().get_count("ToDo") == 7
@@ -154,7 +156,7 @@ def test_cross_host_redirect_does_not_forward_credential():
 
 @respx.mock
 def test_debug_requests_sql_and_emits_server_debug(capsys):
-    route = respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+    route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -168,16 +170,18 @@ def test_debug_requests_sql_and_emits_server_debug(capsys):
         )
     )
     FrappeClient(BASE, "k:s", debug=True).list_documents("ToDo", fields=["name"])
-    assert route.calls.last.request.url.params["debug"] == "true"
+    assert json.loads(route.calls.last.request.content)["debug"] == "true"
     err = capsys.readouterr().err
-    assert "→ GET" in err
+    assert "→ QUERY" in err
     assert "authorization: token ***" in err
     assert "[server] SELECT `name` FROM `tabToDo` LIMIT 1" in err
 
 
 @respx.mock
 def test_debug_emits_server_traceback_on_error(capsys):
-    respx.get(f"{BASE}/api/v2/method/suite.mail.api.mail.get_all_inbox_threads").mock(
+    respx.request(
+        "QUERY", f"{BASE}/api/v2/method/suite.mail.api.mail.get_all_inbox_threads"
+    ).mock(
         return_value=httpx.Response(
             500,
             json={
@@ -208,7 +212,7 @@ def test_debug_emits_server_traceback_on_error(capsys):
 
 @respx.mock
 def test_no_server_traceback_without_debug(capsys):
-    respx.get(f"{BASE}/api/v2/method/x.y").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/method/x.y").mock(
         return_value=httpx.Response(
             500,
             json={"errors": [{"exception": "Traceback...\nKeyError: 'z'"}]},
@@ -223,7 +227,7 @@ def test_no_server_traceback_without_debug(capsys):
 
 @respx.mock
 def test_server_exception_not_flagged_under_debug():
-    respx.get(f"{BASE}/api/v2/method/x.y").mock(
+    respx.request("QUERY", f"{BASE}/api/v2/method/x.y").mock(
         return_value=httpx.Response(
             500,
             json={"errors": [{"exception": "Traceback...\nKeyError: 'z'"}]},
@@ -251,11 +255,11 @@ def test_error_without_traceback_not_flagged():
 
 @respx.mock
 def test_no_debug_param_or_output_by_default(capsys):
-    route = respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+    route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
         return_value=httpx.Response(200, json={"data": [], "has_next_page": False})
     )
     client().list_documents("ToDo", fields=["name"])
-    assert "debug" not in route.calls.last.request.url.params
+    assert "debug" not in json.loads(route.calls.last.request.content)
     assert capsys.readouterr().err == ""
 
 
@@ -303,11 +307,98 @@ def test_read_only_refuses_writes(call):
 
 
 @respx.mock
-def test_read_only_get_method_call_allowed():
-    route = respx.get(f"{BASE}/api/v2/method/frappe.client.get_count").mock(
-        return_value=httpx.Response(200, json={"data": 3})
-    )
+def test_read_only_get_method_call_prefers_query():
+    route = respx.request(
+        "QUERY", f"{BASE}/api/v2/method/frappe.client.get_count"
+    ).mock(return_value=httpx.Response(200, json={"data": 3}))
     assert ro_client().call_method("frappe.client.get_count", http_method="GET") == 3
+    assert route.called
+
+
+@respx.mock
+def test_read_only_list_sends_query_with_json_body():
+    route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(
+            200, json={"data": [{"name": "a"}], "has_next_page": False}
+        )
+    )
+    rows, _ = ro_client().list_documents(
+        "ToDo", fields=["name"], filters={"status": "Open"}, limit=2
+    )
+    assert rows == [{"name": "a"}]
+    body = json.loads(route.calls.last.request.content)
+    assert body["fields"] == ["name"]
+    assert body["filters"] == {"status": "Open"}
+    assert body["limit"] == 2
+
+
+@respx.mock
+def test_query_falls_back_to_get_and_is_remembered():
+    respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(405)
+    )
+    get_route = respx.get(f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(200, json={"data": [], "has_next_page": False})
+    )
+    c = ro_client()
+    c.list_documents("ToDo", filters={"status": "Open"})
+    # The GET fallback re-encodes containers for the query string.
+    assert get_route.calls.last.request.url.params["filters"] == '{"status": "Open"}'
+    # The failed probe is remembered: the next read goes straight to GET.
+    c.list_documents("ToDo")
+    query_route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo")
+    assert len(query_route.calls) == 1
+    assert len(get_route.calls) == 2
+
+
+@respx.mock
+def test_query_success_skips_future_fallback_probes():
+    route = respx.request("QUERY", f"{BASE}/api/v2/doctype/ToDo/count").mock(
+        return_value=httpx.Response(200, json={"data": 7})
+    )
+    c = ro_client()
+    assert c.get_count("ToDo", filters={"status": "Open"}) == 7
+    assert c.get_count("ToDo") == 7
+    assert len(route.calls) == 2
+    assert json.loads(route.calls[0].request.content)["filters"] == {"status": "Open"}
+
+
+@respx.mock
+def test_query_double_failure_surfaces_get_error_and_reprobes():
+    respx.request("QUERY", f"{BASE}/api/v2/method/x.y").mock(
+        return_value=httpx.Response(403, json={"errors": [{"message": "nope"}]})
+    )
+    respx.get(f"{BASE}/api/v2/method/x.y").mock(
+        return_value=httpx.Response(403, json={"errors": [{"message": "nope"}]})
+    )
+    c = ro_client()
+    with pytest.raises(FrappeError) as ei:
+        c.call_method("x.y", http_method="GET")
+    assert ei.value.status_code == 403
+    # A double failure proves nothing about QUERY support: the next read
+    # probes QUERY again instead of settling on GET.
+    with pytest.raises(FrappeError):
+        c.call_method("x.y", http_method="GET")
+    query_route = respx.request("QUERY", f"{BASE}/api/v2/method/x.y")
+    assert len(query_route.calls) == 2
+
+
+@respx.mock
+def test_writable_profile_also_prefers_query():
+    route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(200, json={"data": [], "has_next_page": False})
+    )
+    client().list_documents("ToDo", filters={"status": "Open"})
+    assert route.called
+    assert json.loads(route.calls.last.request.content)["filters"] == {"status": "Open"}
+
+
+@respx.mock
+def test_read_only_allows_explicit_query_request():
+    route = respx.request("QUERY", f"{BASE}/api/v2/document/ToDo").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    assert ro_client().request("QUERY", "/api/v2/document/ToDo", json_body={}) == []
     assert route.called
 
 

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -386,8 +386,8 @@ def test_method_call_explicit_get_skips_detail_fetch(env):
     detail = respx.get(
         f"{BASE}/api/v2/discovery/doctype/User/method/get_something"
     ).mock(return_value=httpx.Response(200, json={"data": {}}))
-    invoke = respx.get(
-        f"{BASE}/api/v2/document/User/Administrator/method/get_something"
+    invoke = respx.request(
+        "QUERY", f"{BASE}/api/v2/document/User/Administrator/method/get_something"
     ).mock(return_value=httpx.Response(200, json={"data": {"ok": 1}}))
     result = runner.invoke(
         app,
@@ -461,7 +461,7 @@ def test_method_call_rpc_explicit_get_hits_method_endpoint(env):
     detail = respx.get(f"{BASE}/api/v2/discovery/method/frappe.ping").mock(
         return_value=httpx.Response(200, json={"data": {}})
     )
-    invoke = respx.get(f"{BASE}/api/v2/method/frappe.ping").mock(
+    invoke = respx.request("QUERY", f"{BASE}/api/v2/method/frappe.ping").mock(
         return_value=httpx.Response(200, json={"data": "pong"})
     )
     result = runner.invoke(
@@ -473,14 +473,15 @@ def test_method_call_rpc_explicit_get_hits_method_endpoint(env):
 
 
 @respx.mock
-def test_method_call_read_only_defaults_to_get(monkeypatch):
+def test_method_call_read_only_defaults_to_safe_verb(monkeypatch):
     monkeypatch.setenv("FRAPPE_SITE", BASE)
     monkeypatch.setenv("FRAPPE_API_KEY", "k")
     monkeypatch.setenv("FRAPPE_API_SECRET", "s")
     monkeypatch.setenv("FRAPPE_READ_ONLY", "1")
-    invoke = respx.get(f"{BASE}/api/v2/method/frappe.client.get_count").mock(
-        return_value=httpx.Response(200, json={"data": 3})
-    )
+    # Read-only profiles prefer the QUERY verb for GET-shaped calls.
+    invoke = respx.request(
+        "QUERY", f"{BASE}/api/v2/method/frappe.client.get_count"
+    ).mock(return_value=httpx.Response(200, json={"data": 3}))
     result = runner.invoke(
         app,
         ["--json", "method", "call", "frappe.client.get_count", "-F", "doctype=User"],


### PR DESCRIPTION
## What

Reads on QUERY-mounted routes — document list, count, RPC and doc-method calls with GET semantics — now go out as **QUERY** (frappe/frappe#41135) instead of GET, for all profiles. Servers that don't speak the verb transparently fall back to plain GET.

## Why

QUERY is GET's transaction semantics with POST's body semantics, which buys two things:

- **Complex payloads ride in a JSON body.** Filters, fields and report params travel as native JSON instead of the JSON-in-query-string encoding, so they aren't subject to URL length limits.
- **Read-only is enforced server-side.** The server rolls the transaction back at the end of the request, so a read-only profile's guarantee no longer rests on every whitelisted endpoint being well-behaved.

## How

- `transport.send_read()` sends QUERY first. A 403/404/405/501 means "this server doesn't speak QUERY" (routing rejects the verb, or pre-QUERY whitelisting throws `PermissionError`), so it retries as GET.
- The outcome is cached per client, so only the first read pays the probe. **Only a fallback that succeeds settles the cache** — when both verbs fail (e.g. a genuine 403) the error surfaces unchanged and the next read probes again. This also means falling back never masks a real error; it only costs one extra request.
- GET-only routes (single-doc read, meta, discovery, downloads) deliberately stay on GET: the server doesn't mount QUERY there, and probing them would mis-teach the cache.
- QUERY joins the safe-method set, so read-only profiles permit it and `api -X QUERY` works as an explicit escape hatch. The raw `api` command otherwise keeps whatever verb you give it.

Not touched: the System Console SQL path — `execute_code` is whitelisted `methods=["POST"]` upstream, so QUERY can't reach it until frappe allows the verb there.

## Tests

Unit tests cover the QUERY body encoding, fallback-and-remember, double-failure re-probe, and the GET re-encoding of container params. Verified E2E against a local bench: `doc list`, `method call` (RPC + doc-method), `report run` and `auth whoami` all go out as QUERY and fall back correctly.