### PR TITLE
fix: Make new auth profiles read-only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ to skip the authentication-method prompt.
 
 ### Read-only profiles
 
-A read-only profile refuses every unsafe HTTP method **before the request leaves your
-machine**. This removes the obvious production footgun: an exploratory command can't
-accidentally mutate the site.
+A new profile is read-only by default and refuses every unsafe HTTP method **before
+the request leaves your machine**. This removes the obvious production footgun: an
+exploratory command can't accidentally mutate the site. Choose `--writable` during
+login to opt out.
 
 ```sh
-frappectl auth login https://prod.example.com --name prod --read-only
+frappectl auth login https://prod.example.com --name prod
+frappectl auth login https://dev.example.com --name dev --writable
 frappectl auth configure prod --read-only             # lock an existing profile
 frappectl auth configure prod --writable              # allow writes again
 ```

--- a/src/frappectl/commands/auth.py
+++ b/src/frappectl/commands/auth.py
@@ -39,9 +39,7 @@ def _choose_read_only(read_only: Optional[bool]) -> bool:
     """Default new profiles to read-only unless explicitly made writable."""
     if read_only is not None:
         return read_only
-    return typer.confirm(
-        "Read-only? (refuse all writes through this profile)", default=True
-    )
+    return not typer.confirm("Allow writes through this profile?", default=False)
 
 
 @app.command("login")

--- a/src/frappectl/commands/auth.py
+++ b/src/frappectl/commands/auth.py
@@ -35,6 +35,15 @@ def _choose_oauth(use_oauth: bool) -> bool:
         typer.echo("Choose either 'oauth' or 'api-key'.", err=True)
 
 
+def _choose_read_only(read_only: Optional[bool]) -> bool:
+    """Default new profiles to read-only unless explicitly made writable."""
+    if read_only is not None:
+        return read_only
+    return typer.confirm(
+        "Read-only? (refuse all writes through this profile)", default=True
+    )
+
+
 @app.command("login")
 def login(
     ctx: typer.Context,
@@ -112,12 +121,8 @@ def login(
         description = typer.prompt(
             "Description (used by assistant mode; optional)", default=""
         )
-    # Read-only is prompted like the other fields when not set explicitly;
-    # default No so a plain Enter keeps the profile writable.
-    if read_only is None:
-        read_only = typer.confirm(
-            "Read-only? (refuse all writes through this profile)", default=False
-        )
+    # New profiles are safe by default; --writable remains an explicit opt-out.
+    read_only = _choose_read_only(read_only)
 
     use_oauth = _choose_oauth(use_oauth)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,6 +206,31 @@ def test_oauth_flag_skips_authentication_choice(monkeypatch):
     assert auth._choose_oauth(True) is True
 
 
+def test_login_defaults_new_profile_to_read_only(monkeypatch):
+    prompted = {}
+
+    def confirm(message, *, default):
+        prompted.update(message=message, default=default)
+        return default
+
+    monkeypatch.setattr(auth.typer, "confirm", confirm)
+
+    assert auth._choose_read_only(None) is True
+    assert prompted == {
+        "message": "Read-only? (refuse all writes through this profile)",
+        "default": True,
+    }
+
+
+def test_login_writable_flag_overrides_read_only_default(monkeypatch):
+    def unexpected_confirm(*args, **kwargs):
+        raise AssertionError("--writable should skip the read-only prompt")
+
+    monkeypatch.setattr(auth.typer, "confirm", unexpected_confirm)
+
+    assert auth._choose_read_only(False) is False
+
+
 @respx.mock
 def test_get_logged_user_only_trusts_non_guest_data():
     route = respx.get(f"{BASE}/api/v2/method/frappe.auth.get_logged_user")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,8 +217,8 @@ def test_login_defaults_new_profile_to_read_only(monkeypatch):
 
     assert auth._choose_read_only(None) is True
     assert prompted == {
-        "message": "Read-only? (refuse all writes through this profile)",
-        "default": True,
+        "message": "Allow writes through this profile?",
+        "default": False,
     }
 
 


### PR DESCRIPTION
## Summary

- default the interactive auth login safety prompt to read-only
- preserve `--writable` as an explicit opt-out
- document the new default and cover both paths with tests

## Testing

- `uv run pytest` (228 passed, 14 skipped)
- `uv run mypy src`