### PR TITLE
perf: trim outputs, save some tokens!

### DIFF
--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -176,6 +176,8 @@ def _slim_document(doc: Document) -> Document:
     for key, value in doc.items():
         if key == "idx":
             continue
+        if key == "amended_from" and value is None:
+            continue
         if isinstance(value, list) and value and isinstance(value[0], dict):
             slim[key] = [
                 {k: v for k, v in row.items() if k not in _CHILD_BOILERPLATE}

--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -172,17 +172,20 @@ def _slim_document(doc: Document) -> Document:
     """Strip values a reader can derive from the parent or does not need.
 
     Child rows repeat the parent's ownership, timestamps and docstatus on every
-    row, which dominates the output of a document with large tables.
+    row, which dominates the output of a document with large tables. A null
+    field says only that the field exists, which the schema already states.
     """
     slim: Document = {}
     for key, value in doc.items():
-        if key == "idx":
-            continue
-        if key == "amended_from" and value is None:
+        if key == "idx" or value is None:
             continue
         if isinstance(value, list) and value and isinstance(value[0], dict):
             slim[key] = [
-                {k: v for k, v in row.items() if k not in _CHILD_BOILERPLATE}
+                {
+                    k: v
+                    for k, v in row.items()
+                    if k not in _CHILD_BOILERPLATE and v is not None
+                }
                 if isinstance(row, dict)
                 else row
                 for row in value

--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -155,6 +155,7 @@ def _fetch(
 
 
 _CHILD_BOILERPLATE = {
+    "doctype",
     "owner",
     "creation",
     "modified",

--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -164,6 +164,7 @@ _CHILD_BOILERPLATE = {
     "parent",
     "parentfield",
     "parenttype",
+    "idx",
 }
 
 

--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -155,6 +155,7 @@ def _fetch(
 
 
 _CHILD_BOILERPLATE = {
+    "name",
     "doctype",
     "owner",
     "creation",

--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -154,6 +154,38 @@ def _fetch(
     return all_rows
 
 
+_CHILD_BOILERPLATE = {
+    "owner",
+    "creation",
+    "modified",
+    "modified_by",
+    "docstatus",
+    "parent",
+    "parentfield",
+    "parenttype",
+}
+
+
+def _slim_document(doc: Document) -> Document:
+    """Strip values a reader can derive from the parent or does not need.
+
+    Child rows repeat the parent's ownership, timestamps and docstatus on every
+    row, which dominates the output of a document with large tables.
+    """
+    slim: Document = {}
+    for key, value in doc.items():
+        if isinstance(value, list) and value and isinstance(value[0], dict):
+            slim[key] = [
+                {k: v for k, v in row.items() if k not in _CHILD_BOILERPLATE}
+                if isinstance(row, dict)
+                else row
+                for row in value
+            ]
+        else:
+            slim[key] = value
+    return slim
+
+
 @app.command("get")
 def get_doc(
     ctx: typer.Context,
@@ -167,7 +199,7 @@ def get_doc(
         doc = client.get_document(doctype, name)
     except FrappeError as e:
         raise fail(e.message)
-    emit_record(c, doc, title=f"{doctype} {name}")
+    emit_record(c, _slim_document(doc), title=f"{doctype} {name}")
 
 
 @app.command("create")

--- a/src/frappectl/commands/doc.py
+++ b/src/frappectl/commands/doc.py
@@ -174,6 +174,8 @@ def _slim_document(doc: Document) -> Document:
     """
     slim: Document = {}
     for key, value in doc.items():
+        if key == "idx":
+            continue
         if isinstance(value, list) and value and isinstance(value[0], dict):
             slim[key] = [
                 {k: v for k, v in row.items() if k not in _CHILD_BOILERPLATE}

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -95,36 +95,38 @@ def show_doctype(
         if f.get("fieldtype") in {"Table", "Table MultiSelect"}
     ]
 
-    if c.json:
-        print_json(
-            {
-                "name": meta.get("name"),
-                "module": meta.get("module"),
-                "issingle": meta.get("issingle"),
-                "istable": meta.get("istable"),
-                "is_submittable": meta.get("is_submittable"),
-                "title_field": meta.get("title_field"),
-                "autoname": meta.get("autoname"),
-                "fields": fields,
-                "links": links,
-                "child_tables": child_tables,
-                "permissions": meta.get("permissions", []),
-            }
-        )
-        return
+    is_virtual = bool(meta.get("is_virtual"))
 
-    emit_record(
-        c,
-        {
+    if c.json:
+        payload = {
             "name": meta.get("name"),
             "module": meta.get("module"),
-            "is_submittable": bool(meta.get("is_submittable")),
-            "issingle": bool(meta.get("issingle")),
+            "issingle": meta.get("issingle"),
+            "istable": meta.get("istable"),
+            "is_submittable": meta.get("is_submittable"),
             "title_field": meta.get("title_field"),
             "autoname": meta.get("autoname"),
-        },
-        title=f"DocType {name}",
-    )
+            "fields": fields,
+            "links": links,
+            "child_tables": child_tables,
+            "permissions": meta.get("permissions", []),
+        }
+        if is_virtual:
+            payload["is_virtual"] = True
+        print_json(payload)
+        return
+
+    record: Document = {
+        "name": meta.get("name"),
+        "module": meta.get("module"),
+        "is_submittable": bool(meta.get("is_submittable")),
+        "issingle": bool(meta.get("issingle")),
+        "title_field": meta.get("title_field"),
+        "autoname": meta.get("autoname"),
+    }
+    if is_virtual:
+        record["is_virtual"] = True
+    emit_record(c, record, title=f"DocType {name}")
     emit_list(
         c,
         fields,

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -52,8 +52,9 @@ def _summarize_field(df: Document, in_list_view: bool = False) -> Document:
         "label": df.get("label"),
         "fieldtype": df.get("fieldtype"),
         "options": df.get("options"),
-        "reqd": bool(df.get("reqd")),
     }
+    if df.get("reqd"):
+        summary["reqd"] = True
     if in_list_view:
         summary["in_list_view"] = bool(df.get("in_list_view"))
     return summary

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -61,8 +61,26 @@ def _summarize_field(df: Document, in_list_view: bool = False) -> Document:
     return summary
 
 
+_PERM_BOILERPLATE = {
+    "doctype",
+    "name",
+    "creation",
+    "modified",
+    "modified_by",
+    "owner",
+    "parent",
+    "parentfield",
+    "parenttype",
+    "idx",
+}
+
+
 def _summarize_permission(perm: Document) -> Document:
-    return {k: v for k, v in perm.items() if v != 0 or k == "permlevel"}
+    return {
+        k: v
+        for k, v in perm.items()
+        if k not in _PERM_BOILERPLATE and (v != 0 or k == "permlevel")
+    }
 
 
 @app.command("show")

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -51,8 +51,9 @@ def _summarize_field(df: Document, in_list_view: bool = False) -> Document:
         "fieldname": df.get("fieldname"),
         "label": df.get("label"),
         "fieldtype": df.get("fieldtype"),
-        "options": df.get("options"),
     }
+    if df.get("options"):
+        summary["options"] = df.get("options")
     if df.get("reqd"):
         summary["reqd"] = True
     if in_list_view:

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -61,6 +61,10 @@ def _summarize_field(df: Document, in_list_view: bool = False) -> Document:
     return summary
 
 
+def _summarize_permission(perm: Document) -> Document:
+    return {k: v for k, v in perm.items() if v != 0}
+
+
 @app.command("show")
 def show_doctype(
     ctx: typer.Context,
@@ -111,7 +115,9 @@ def show_doctype(
             "fields": fields,
             "links": links,
             "child_tables": child_tables,
-            "permissions": meta.get("permissions", []),
+            "permissions": [
+                _summarize_permission(p) for p in meta.get("permissions", [])
+            ],
         }
         if is_virtual:
             payload["is_virtual"] = True

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -36,14 +36,14 @@ def list_doctypes(
     try:
         rows, _ = client.list_documents(
             "DocType",
-            fields=["name", "module", "issingle", "istable", "custom"],
+            fields=["name", "module"],
             filters=filters or None,
             order_by="name asc",
             limit=limit,
         )
     except FrappeError as e:
         raise fail(e.message)
-    emit_list(c, rows, ["name", "module", "issingle", "istable", "custom"])
+    emit_list(c, rows, ["name", "module"])
 
 
 def _summarize_field(df: Document) -> Document:

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -11,9 +11,7 @@ from ..errors import FrappeError
 from ..output import emit_list, emit_record, fail, get_ctx, print_json
 from ..session import get_client
 
-app = typer.Typer(
-    no_args_is_help=True, help="Inspect DocTypes: fields, links, permissions."
-)
+app = typer.Typer(no_args_is_help=True, help="Inspect DocTypes: fields, permissions.")
 
 
 @app.command("list")
@@ -89,7 +87,7 @@ def show_doctype(
     name: str = typer.Argument(..., help="DocType name."),
     raw: bool = typer.Option(False, "--raw", help="Print the full unprocessed meta."),
 ) -> None:
-    """Show fields, types, link targets and permissions."""
+    """Show fields, types and permissions."""
     c = get_ctx(ctx)
     client = get_client(c)
     try:
@@ -108,11 +106,6 @@ def show_doctype(
         for f in all_fields
         if f.get("fieldtype") not in layout
     ]
-    links = [
-        {"fieldname": f.get("fieldname"), "target": f.get("options")}
-        for f in all_fields
-        if f.get("fieldtype") == "Link"
-    ]
     is_virtual = bool(meta.get("is_virtual"))
 
     if c.json:
@@ -125,7 +118,6 @@ def show_doctype(
             "title_field": meta.get("title_field"),
             "autoname": meta.get("autoname"),
             "fields": fields,
-            "links": links,
             "permissions": [
                 _summarize_permission(p) for p in meta.get("permissions", [])
             ],

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -62,7 +62,7 @@ def _summarize_field(df: Document, in_list_view: bool = False) -> Document:
 
 
 def _summarize_permission(perm: Document) -> Document:
-    return {k: v for k, v in perm.items() if v != 0}
+    return {k: v for k, v in perm.items() if v != 0 or k == "permlevel"}
 
 
 @app.command("show")

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -89,7 +89,7 @@ def show_doctype(
     name: str = typer.Argument(..., help="DocType name."),
     raw: bool = typer.Option(False, "--raw", help="Print the full unprocessed meta."),
 ) -> None:
-    """Show fields, types, link targets, child tables and permissions."""
+    """Show fields, types, link targets and permissions."""
     c = get_ctx(ctx)
     client = get_client(c)
     try:
@@ -113,12 +113,6 @@ def show_doctype(
         for f in all_fields
         if f.get("fieldtype") == "Link"
     ]
-    child_tables = [
-        {"fieldname": f.get("fieldname"), "child_doctype": f.get("options")}
-        for f in all_fields
-        if f.get("fieldtype") in {"Table", "Table MultiSelect"}
-    ]
-
     is_virtual = bool(meta.get("is_virtual"))
 
     if c.json:
@@ -132,7 +126,6 @@ def show_doctype(
             "autoname": meta.get("autoname"),
             "fields": fields,
             "links": links,
-            "child_tables": child_tables,
             "permissions": [
                 _summarize_permission(p) for p in meta.get("permissions", [])
             ],
@@ -158,8 +151,3 @@ def show_doctype(
         fields,
         ["fieldname", "label", "fieldtype", "options", "reqd", "in_list_view"],
     )
-    if child_tables:
-        from ..output import err_console
-
-        err_console.print("[bold]Child tables[/bold]")
-        emit_list(c, child_tables, ["fieldname", "child_doctype"])

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -46,15 +46,17 @@ def list_doctypes(
     emit_list(c, rows, ["name", "module"])
 
 
-def _summarize_field(df: Document) -> Document:
-    return {
+def _summarize_field(df: Document, in_list_view: bool = False) -> Document:
+    summary: Document = {
         "fieldname": df.get("fieldname"),
         "label": df.get("label"),
         "fieldtype": df.get("fieldtype"),
         "options": df.get("options"),
         "reqd": bool(df.get("reqd")),
-        "in_list_view": bool(df.get("in_list_view")),
     }
+    if in_list_view:
+        summary["in_list_view"] = bool(df.get("in_list_view"))
+    return summary
 
 
 @app.command("show")
@@ -78,7 +80,9 @@ def show_doctype(
     all_fields = meta.get("fields", [])
     layout = {"Section Break", "Column Break", "Tab Break", "HTML", "Heading"}
     fields = [
-        _summarize_field(f) for f in all_fields if f.get("fieldtype") not in layout
+        _summarize_field(f, in_list_view=not c.json)
+        for f in all_fields
+        if f.get("fieldtype") not in layout
     ]
     links = [
         {"fieldname": f.get("fieldname"), "target": f.get("options")}

--- a/src/frappectl/commands/doctype.py
+++ b/src/frappectl/commands/doctype.py
@@ -34,14 +34,17 @@ def list_doctypes(
     try:
         rows, _ = client.list_documents(
             "DocType",
-            fields=["name", "module"],
+            fields=["name"],
             filters=filters or None,
             order_by="name asc",
             limit=limit,
         )
     except FrappeError as e:
         raise fail(e.message)
-    emit_list(c, rows, ["name", "module"])
+    if c.json:
+        print_json([row.get("name") for row in rows])
+        return
+    emit_list(c, rows, ["name"])
 
 
 def _summarize_field(df: Document, in_list_view: bool = False) -> Document:

--- a/src/frappectl/commands/guide.py
+++ b/src/frappectl/commands/guide.py
@@ -33,7 +33,7 @@ SITE ACCESS
 ORIENT YOURSELF (do this before you guess a field name or a DocType name)
   frappectl doctype list                           # all DocTypes on the site
   frappectl doctype list --module HR --custom      # a smaller list
-  frappectl doctype show "Sales Invoice"           # fields, types, links, required, child tables
+  frappectl doctype show "Sales Invoice"           # fields, types, links, required
   frappectl doctype show "Sales Invoice" --raw     # the full meta, without processing
 
 DOCUMENTS (create, read, update, delete, and lifecycle)

--- a/src/frappectl/commands/guide.py
+++ b/src/frappectl/commands/guide.py
@@ -33,7 +33,7 @@ SITE ACCESS
 ORIENT YOURSELF (do this before you guess a field name or a DocType name)
   frappectl doctype list                           # all DocTypes on the site
   frappectl doctype list --module HR --custom      # a smaller list
-  frappectl doctype show "Sales Invoice"           # fields, types, links, required
+  frappectl doctype show "Sales Invoice"           # fields, types, required
   frappectl doctype show "Sales Invoice" --raw     # the full meta, without processing
 
 DOCUMENTS (create, read, update, delete, and lifecycle)

--- a/src/frappectl/output.py
+++ b/src/frappectl/output.py
@@ -116,7 +116,7 @@ def get_ctx(ctx: typer.Context) -> ApplicationContext:
     return obj
 
 
-_JSON_WIDTH = 100
+_JSON_WIDTH = 160
 
 
 def _dumps(value: Any, level: int) -> str:

--- a/src/frappectl/output.py
+++ b/src/frappectl/output.py
@@ -116,8 +116,33 @@ def get_ctx(ctx: typer.Context) -> ApplicationContext:
     return obj
 
 
+_JSON_WIDTH = 100
+
+
+def _dumps(value: Any, level: int) -> str:
+    """Render one value, inline when it fits on a line and expanded when not."""
+    inline = json.dumps(value, separators=(",", ":"), default=str, ensure_ascii=False)
+    if level + len(inline) <= _JSON_WIDTH or not isinstance(value, (dict, list)):
+        return inline
+    pad = " " * level
+    if isinstance(value, dict):
+        body = ",\n".join(
+            f"{pad} {json.dumps(str(k), ensure_ascii=False)}:{_dumps(v, level + 1)}"
+            for k, v in value.items()
+        )
+        return f"{{\n{body}\n{pad}}}"
+    body = ",\n".join(f"{pad} {_dumps(v, level + 1)}" for v in value)
+    return f"[\n{body}\n{pad}]"
+
+
 def print_json(data: Any) -> None:
-    sys.stdout.write(json.dumps(data, indent=2, default=str, ensure_ascii=False))
+    """Write JSON to stdout, one line per value that does not fit inline.
+
+    Padding and deep indentation cost a token on every line and tell the
+    reader nothing. A child row or a short list therefore stays on one line,
+    and only a value wider than the line limit opens up.
+    """
+    sys.stdout.write(_dumps(data, 0))
     sys.stdout.write("\n")
 
 

--- a/src/frappectl/output.py
+++ b/src/frappectl/output.py
@@ -141,8 +141,19 @@ def print_json(data: Any) -> None:
     Padding and deep indentation cost a token on every line and tell the
     reader nothing. A child row or a short list therefore stays on one line,
     and only a value wider than the line limit opens up.
+
+    The layout is assembled by hand, so the result is parsed once before it
+    goes out. A caller that pipes the output must never receive broken JSON.
+    A parse failure is a bug in the layout, so it goes to stderr, and the
+    standard encoder writes the value instead.
     """
-    sys.stdout.write(_dumps(data, 0))
+    text = _dumps(data, 0)
+    try:
+        json.loads(text)
+    except ValueError as e:
+        err_console.print(f"[dim]internal: compact JSON layout failed ({e})[/dim]")
+        text = json.dumps(data, default=str, ensure_ascii=False)
+    sys.stdout.write(text)
     sys.stdout.write("\n")
 
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -75,8 +75,8 @@ def test_whoami_authenticates():
 
 
 def test_doctype_list_includes_todo():
-    rows = run_json("doctype", "list")
-    assert DOCTYPE in {r["name"] for r in rows}
+    names = run_json("doctype", "list")
+    assert DOCTYPE in set(names)
 
 
 def test_doctype_show_exposes_fields():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import pytest
 import respx
@@ -45,7 +47,7 @@ def test_doc_get_json(env):
     )
     result = runner.invoke(app, ["--json", "doc", "get", "ToDo", "X"])
     assert result.exit_code == 0
-    assert '"name": "X"' in result.stdout
+    assert json.loads(result.stdout) == {"name": "X", "status": "Open"}
 
 
 @respx.mock
@@ -88,7 +90,7 @@ def test_delete_runs_without_confirmation(env):
     result = runner.invoke(app, ["--json", "doc", "delete", "ToDo", "X"])
     assert result.exit_code == 0
     assert route.called
-    assert '"deleted": "X"' in result.stdout
+    assert json.loads(result.stdout)["deleted"] == "X"
 
 
 @respx.mock

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import pytest
 import respx
@@ -88,7 +90,7 @@ def test_method_search_json_is_raw(env):
     )
     result = runner.invoke(app, ["--json", "method", "search", "--query=abc"])
     assert result.exit_code == 0
-    assert '"query": "abc"' in result.stdout
+    assert json.loads(result.stdout)["query"] == "abc"
     assert "frappe.ping" in result.stdout
 
 
@@ -530,4 +532,4 @@ def test_method_show_json_preserved_after_503_retry(env):
     )
     result = runner.invoke(app, ["--json", "method", "show", "frappe.ping"])
     assert result.exit_code == 0
-    assert '"path": "frappe.ping"' in result.stdout
+    assert json.loads(result.stdout)["path"] == "frappe.ping"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+from frappectl.output import _JSON_WIDTH, print_json
+
+CASES = [
+    "Administrator",
+    42,
+    None,
+    True,
+    [],
+    {},
+    ["ToDo", "User", "Item"],
+    {"name": "X", "status": "Open"},
+    {
+        "items": [
+            {"item_code": f"ITEM-{i:03d}", "qty": i, "rate": i * 1.5} for i in range(20)
+        ]
+    },
+    {"deep": {"a": {"b": {"c": ["x" * 200, {"d": [1, 2, 3]}]}}}},
+    {"unicode": "café ☕", "quote": 'a "quoted" value', "newline": "line\nbreak"},
+]
+
+
+@pytest.mark.parametrize("data", CASES)
+def test_print_json_round_trips(data, capsys):
+    print_json(data)
+    assert json.loads(capsys.readouterr().out) == data
+
+
+@pytest.mark.parametrize("data", CASES)
+def test_print_json_respects_the_width_limit(data, capsys):
+    print_json(data)
+    lines = capsys.readouterr().out.splitlines()
+    # A line holding one long scalar can exceed the limit. Nothing can split it.
+    splittable = [line for line in lines if "{" in line or "[" in line]
+    assert all(len(line) <= _JSON_WIDTH for line in splittable)
+
+
+def test_print_json_keeps_a_short_value_on_one_line(capsys):
+    print_json({"items": [{"item_code": "A", "qty": 1}]})
+    assert capsys.readouterr().out == '{"items":[{"item_code":"A","qty":1}]}\n'
+
+
+def test_print_json_expands_a_wide_value(capsys):
+    print_json({"tags": ["tag-" + "x" * 40 for _ in range(6)]})
+    out = capsys.readouterr().out
+    assert out.startswith("{\n")
+    assert len(out.splitlines()) > 1

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -43,6 +43,12 @@ def test_print_json_keeps_a_short_value_on_one_line(capsys):
     assert capsys.readouterr().out == '{"items":[{"item_code":"A","qty":1}]}\n'
 
 
+def test_print_json_falls_back_when_the_layout_breaks(capsys, monkeypatch):
+    monkeypatch.setattr("frappectl.output._dumps", lambda value, level: "{broken")
+    print_json({"name": "X"})
+    assert json.loads(capsys.readouterr().out) == {"name": "X"}
+
+
 def test_print_json_expands_a_wide_value(capsys):
     print_json({"tags": ["tag-" + "x" * 40 for _ in range(6)]})
     out = capsys.readouterr().out


### PR DESCRIPTION
`doctype show`, `doctype list` and `doc get` return more text than a reader
needs. This branch removes the repeated values and the defaults. The output
keeps the same information in fewer tokens.

### `doctype list`

- The command prints a plain JSON list of DocType names.
- The `module`, `issingle`, `istable` and `custom` columns are gone. Use
  `--module` to narrow the list, or read `doctype show` for one DocType.

### `doctype show`

- The JSON output drops `in_list_view`. The table output keeps it.
- A field shows `reqd` only when the field is mandatory.
- A field shows `options` only when the field has options.
- The `links` and `child_tables` sections are gone. Link, Table and Table
  MultiSelect fields already name the target in `options`.
- A permission row keeps the granted flags and `permlevel`. The zero flags and
  the DocPerm row boilerplate are gone.
- A virtual DocType shows `is_virtual`. A virtual DocType has no database
  table, so the caller must know this before it runs a query.

### `doc get`

- The document drops every field with a null value.
- The document drops the top level `idx`.
- A child row drops `name`, `doctype`, `idx`, `owner`, `creation`, `modified`,
  `modified_by`, `docstatus`, `parent`, `parentfield` and `parenttype`.

`--raw` is unchanged. It still prints the full meta.

---

`frappectl` is not stable, don't rely on output in scripts (!) Use `--raw` if you need those. You should use `--raw` for scripting anyway. That output will not be modified by frappectl.
